### PR TITLE
Changed most of the plain-text blocks to a use a different font

### DIFF
--- a/static/less/ureport2.less
+++ b/static/less/ureport2.less
@@ -1,4 +1,5 @@
 @serif-family: "Times New Roman", Times, serif;
+@sans-serif-family: sans-serif;
 @sans-family: SharpSansBold;
 @font-color: #000;
 
@@ -615,7 +616,7 @@ h1 {
 }
 
 .subsection-content {
-  font-family: @serif-family;
+  font-family: @sans-serif-family;
   font-style: italic;
   line-height: 150%;
   font-size: .8em;
@@ -647,7 +648,7 @@ h1 {
 
 .mission-text {
   text-align: center;
-  font-family: @serif-family;
+  font-family: @sans-serif-family;
   margin-right: 5%;
   font-size: .8em;
   line-height: 150%;
@@ -662,7 +663,7 @@ h1 {
   padding:5px 20px;
 
   ul {
-    font-family: @serif-family;
+    font-family: @sans-serif-family;
     padding-left: 20px;
   }
 }
@@ -933,7 +934,7 @@ ul.poll-filters, .featured-stories-filters, ul.stories-filters {
   .question-title {
     min-height: 100px;
     margin: 0px 10px;
-    font-family: @serif-family;
+    font-family: @sans-serif-family;
     font-size: .85em;
     line-height: 125%;
     background-color: rgba(255, 255, 255, 0.8);
@@ -1056,7 +1057,7 @@ a.brick-link:hover {
 }
 
 .brick-long-story-text {
-  font-family: @serif-family;
+  font-family: @sans-serif-family;
 }
 
 .brick-poll-main-question {
@@ -1093,7 +1094,7 @@ a.brick-link:hover {
 }
 
 .brick-poll-title {
-  font-family: @serif-family;
+  font-family: @sans-serif-family;
   line-height: 130%;
 }
 
@@ -1125,7 +1126,7 @@ a.brick-link:hover {
 }
 
 .yt-block-content {
-  font-family: @serif-family;
+  font-family: @sans-serif-family;
   line-height: 120%;
   margin: 10px 0px;
 }
@@ -1164,7 +1165,7 @@ a.brick-link:hover {
   position: absolute;
   top: 340px;
   padding: 20px;
-  font-family: @serif-family;
+  font-family: @sans-serif-family;
   line-height: 150%;
   font-size: .8em;
 }
@@ -1240,7 +1241,7 @@ a.brick-link:hover {
 }
 
 .ureporters-text {
-  font-family: @serif-family;
+  font-family: @sans-serif-family;
   line-height: 150%;
   padding: 20px;
   background-color: #FFFFFF;
@@ -1248,13 +1249,13 @@ a.brick-link:hover {
 }
 
 .about-details {
-  font-family: @serif-family;
+  font-family: @sans-serif-family;
   line-height: 150%;
   font-size: .8em;
 }
 
 .story-details {
-  font-family: @serif-family;
+  font-family: @sans-serif-family;
   line-height: 150%;
   font-size: .8em;
 }
@@ -1454,7 +1455,7 @@ a.brick-link:hover {
 }
 
 .news-item-description {
-  font-family: @serif-family;
+  font-family: @sans-serif-family;
   margin-bottom: 10px;
 }
 
@@ -1954,7 +1955,7 @@ a.brick-link:hover {
 }
 
 .level-1-title-description {
-  font-family: @serif-family;
+  font-family: @sans-serif-family;
   font-size: .75em;
   font-style: italic;
   line-height: 150%;


### PR DESCRIPTION
- Added a @sans-serif-family var.
- Kept number-based texts on serif/times

![screen shot 2014-11-25 at 4 20 29 pm](https://cloud.githubusercontent.com/assets/57929/5186571/0283dc6a-74bf-11e4-901a-0e4102fee561.png)

@nicpottier Just so you can easily preview/test what it would look like with a different font.