### PR TITLE
Adding questions to polls endpoint

### DIFF
--- a/templates/rest_framework/base.html
+++ b/templates/rest_framework/base.html
@@ -1,0 +1,247 @@
+{% load staticfiles %}
+{% load rest_framework %}
+<!DOCTYPE html>
+<html>
+<head>
+  {% block head %}
+
+    {% block meta %}
+      <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+      <meta name="robots" content="NONE,NOARCHIVE" />
+    {% endblock %}
+
+    <title>{% block title %}Ureport API{% endblock %}</title>
+
+    {% block style %}
+      {% block bootstrap_theme %}
+        <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/bootstrap.min.css" %}"/>
+        <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/bootstrap-tweaks.css" %}"/>
+      {% endblock %}
+
+      <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/prettify.css" %}"/>
+      <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/default.css" %}"/>
+    {% endblock %}
+
+  {% endblock %}
+</head>
+
+{% block body %}
+<body class="{% block bodyclass %}{% endblock %}">
+
+  <div class="wrapper">
+    {% block navbar %}
+      <div class="navbar navbar-static-top {% block bootstrap_navbar_variant %}navbar-inverse{% endblock %}">
+        <div class="container">
+          <span>
+            {% block branding %}
+              <a class='navbar-brand' rel="nofollow" href='http://ureport.in'>
+                  Ureport API <span class="version">0.1.0</span>
+              </a>
+            {% endblock %}
+          </span>
+          <ul class="nav navbar-nav pull-right">
+            {% block userlinks %}
+              {% if user.is_authenticated %}
+                {% optional_logout request user %}
+              {% else %}
+                {% optional_login request %}
+              {% endif %}
+            {% endblock %}
+          </ul>
+        </div>
+      </div>
+    {% endblock %}
+
+    <div class="container">
+      {% block breadcrumbs %}
+        <ul class="breadcrumb">
+          {% for breadcrumb_name, breadcrumb_url in breadcrumblist %}
+            {% if forloop.last %}
+              <li class="active"><a href="{{ breadcrumb_url }}">{{ breadcrumb_name }}</a></li>
+            {% else %}
+              <li><a href="{{ breadcrumb_url }}">{{ breadcrumb_name }}</a></li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      {% endblock %}
+
+      <!-- Content -->
+      <div id="content">
+
+        {% if 'GET' in allowed_methods %}
+          <form id="get-form" class="pull-right">
+            <fieldset>
+              {% if api_settings.URL_FORMAT_OVERRIDE %}
+                <div class="btn-group format-selection">
+                  <a class="btn btn-primary js-tooltip" href="{{ request.get_full_path }}" rel="nofollow" title="Make a GET request on the {{ name }} resource">GET</a>
+
+                  <button class="btn btn-primary dropdown-toggle js-tooltip" data-toggle="dropdown" title="Specify a format for the GET request">
+                    <span class="caret"></span>
+                  </button>
+                  <ul class="dropdown-menu">
+                    {% for format in available_formats %}
+                      <li>
+                        <a class="js-tooltip format-option" href="{% add_query_param request api_settings.URL_FORMAT_OVERRIDE format %}" rel="nofollow" title="Make a GET request on the {{ name }} resource with the format set to `{{ format }}`">{{ format }}</a>
+                      </li>
+                    {% endfor %}
+                  </ul>
+                </div>
+              {% else %}
+                <a class="btn btn-primary js-tooltip" href="{{ request.get_full_path }}" rel="nofollow" title="Make a GET request on the {{ name }} resource">GET</a>
+              {% endif %}
+            </fieldset>
+          </form>
+        {% endif %}
+
+        {% if options_form %}
+          <form class="button-form" action="{{ request.get_full_path }}" method="POST">
+            {% csrf_token %}
+            <input type="hidden" name="{{ api_settings.FORM_METHOD_OVERRIDE }}" value="OPTIONS" />
+            <button class="btn btn-primary js-tooltip" title="Make an OPTIONS request on the {{ name }} resource">OPTIONS</button>
+          </form>
+        {% endif %}
+
+        {% if delete_form %}
+          <form class="button-form" action="{{ request.get_full_path }}" method="POST">
+            {% csrf_token %}
+            <input type="hidden" name="{{ api_settings.FORM_METHOD_OVERRIDE }}" value="DELETE" />
+            <button class="btn btn-danger js-tooltip" title="Make a DELETE request on the {{ name }} resource">DELETE</button>
+          </form>
+        {% endif %}
+
+          <div class="content-main">
+            <div class="page-header">
+                <h1>{{ name }}</h1>
+            </div>
+            <div style="float:left">
+              {% block description %}
+                {{ description }}
+              {% endblock %}
+            </div>
+
+            {% if paginator %}
+              <nav style="float: right">
+                {% get_pagination_html paginator %}
+              </nav>
+            {% endif %}
+
+            <div class="request-info" style="clear: both" >
+              <pre class="prettyprint"><b>{{ request.method }}</b> {{ request.get_full_path }}</pre>
+            </div>
+
+            <div class="response-info">
+              <pre class="prettyprint"><span class="meta nocode"><b>HTTP {{ response.status_code }} {{ response.status_text }}</b>{% autoescape off %}
+{% for key, val in response_headers.items %}<b>{{ key }}:</b> <span class="lit">{{ val|break_long_headers|urlize_quoted_links }}</span>
+{% endfor %}
+</span>{{ content|urlize_quoted_links }}</pre>{% endautoescape %}
+            </div>
+          </div>
+
+          {% if display_edit_forms %}
+
+            {% if post_form or raw_data_post_form %}
+              <div {% if post_form %}class="tabbable"{% endif %}>
+                {% if post_form %}
+                  <ul class="nav nav-tabs form-switcher">
+                    <li>
+                      <a name='html-tab' href="#post-object-form" data-toggle="tab">HTML form</a>
+                    </li>
+                    <li>
+                      <a name='raw-tab' href="#post-generic-content-form" data-toggle="tab">Raw data</a>
+                    </li>
+                  </ul>
+                {% endif %}
+
+                <div class="well tab-content">
+                  {% if post_form %}
+                    <div class="tab-pane" id="post-object-form">
+                      {% with form=post_form %}
+                        <form action="{{ request.get_full_path }}" method="POST" enctype="multipart/form-data" class="form-horizontal" novalidate>
+                          <fieldset>
+                            {{ post_form }}
+                            <div class="form-actions">
+                              <button class="btn btn-primary" title="Make a POST request on the {{ name }} resource">POST</button>
+                            </div>
+                          </fieldset>
+                        </form>
+                      {% endwith %}
+                    </div>
+                  {% endif %}
+
+                  <div {% if post_form %}class="tab-pane"{% endif %} id="post-generic-content-form">
+                    {% with form=raw_data_post_form %}
+                      <form action="{{ request.get_full_path }}" method="POST" class="form-horizontal">
+                        <fieldset>
+                          {% include "rest_framework/raw_data_form.html" %}
+                          <div class="form-actions">
+                            <button class="btn btn-primary" title="Make a POST request on the {{ name }} resource">POST</button>
+                          </div>
+                        </fieldset>
+                      </form>
+                    {% endwith %}
+                  </div>
+                </div>
+              </div>
+            {% endif %}
+
+            {% if put_form or raw_data_put_form or raw_data_patch_form %}
+              <div {% if put_form %}class="tabbable"{% endif %}>
+                {% if put_form %}
+                  <ul class="nav nav-tabs form-switcher">
+                    <li>
+                      <a name='html-tab' href="#put-object-form" data-toggle="tab">HTML form</a>
+                    </li>
+                    <li>
+                      <a  name='raw-tab' href="#put-generic-content-form" data-toggle="tab">Raw data</a>
+                    </li>
+                  </ul>
+                {% endif %}
+
+                <div class="well tab-content">
+                  {% if put_form %}
+                    <div class="tab-pane" id="put-object-form">
+                      <form action="{{ request.get_full_path }}" method="POST" enctype="multipart/form-data" class="form-horizontal" novalidate>
+                        <fieldset>
+                          {{ put_form }}
+                          <div class="form-actions">
+                            <button class="btn btn-primary js-tooltip" name="{{ api_settings.FORM_METHOD_OVERRIDE }}" value="PUT" title="Make a PUT request on the {{ name }} resource">PUT</button>
+                          </div>
+                        </fieldset>
+                      </form>
+                    </div>
+                  {% endif %}
+
+                  <div {% if put_form %}class="tab-pane"{% endif %} id="put-generic-content-form">
+                    {% with form=raw_data_put_or_patch_form %}
+                      <form action="{{ request.get_full_path }}" method="POST" class="form-horizontal">
+                        <fieldset>
+                          {% include "rest_framework/raw_data_form.html" %}
+                          <div class="form-actions">
+                            {% if raw_data_put_form %}
+                              <button class="btn btn-primary js-tooltip" name="{{ api_settings.FORM_METHOD_OVERRIDE }}" value="PUT" title="Make a PUT request on the {{ name }} resource">PUT</button>
+                            {% endif %}
+                            {% if raw_data_patch_form %}
+                              <button class="btn btn-primary js-tooltip" name="{{ api_settings.FORM_METHOD_OVERRIDE }}" value="PATCH" title="Make a PATCH request on the {{ name }} resource">PATCH</button>
+                              {% endif %}
+                          </div>
+                        </fieldset>
+                      </form>
+                    {% endwith %}
+                  </div>
+                </div>
+              </div>
+            {% endif %}
+          {% endif %}
+      </div><!-- /.content -->
+    </div><!-- /.container -->
+  </div><!-- ./wrapper -->
+
+  {% block script %}
+    <script src="{% static "rest_framework/js/jquery-1.8.1-min.js" %}"></script>
+    <script src="{% static "rest_framework/js/bootstrap.min.js" %}"></script>
+    <script src="{% static "rest_framework/js/prettify-min.js" %}"></script>
+    <script src="{% static "rest_framework/js/default.js" %}"></script>
+  {% endblock %}
+</body>
+{% endblock %}
+</html>

--- a/ureport/api/serializers.py
+++ b/ureport/api/serializers.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 from rest_framework.fields import SerializerMethodField
 from ureport.assets.models import Image
 from ureport.news.models import NewsItem, Video
-from ureport.polls.models import Poll
+from ureport.polls.models import Poll, PollQuestion
 
 __author__ = 'kenneth'
 
@@ -19,7 +19,7 @@ class CategoryReadSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Category
-        fields = ('image_url', 'name',)
+        fields = ('image_url', 'name', )
 
     def get_image_url(self, obj):
         image = None
@@ -51,19 +51,32 @@ class StoryReadSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Story
-        fields = ('id', 'title', 'featured', 'summary', 'video_id', 'audio_link', 'tags', 'org', 'images', 'category')
+        fields = ('id', 'title', 'featured', 'summary', 'video_id', 'audio_link', 'tags', 'org', 'images', 'category',
+                  'created_on')
 
     def get_images(self, obj):
         return [generate_absolute_url_from_file(self.context['request'], image.image)
                 for image in obj.get_featured_images()]
 
 
+class PollQuestionReadSerializer(serializers.ModelSerializer):
+    total_summary_data = SerializerMethodField()
+
+    class Meta:
+        model = PollQuestion
+        fields = ('title', 'ruleset_uuid', 'is_open_ended', 'total_summary_data', )
+
+    def get_total_summary_data(self, obj):
+        return obj.get_total_summary_data()
+
+
 class PollReadSerializer(serializers.ModelSerializer):
     category = CategoryReadSerializer()
+    questions = PollQuestionReadSerializer(many=True)
 
     class Meta:
         model = Poll
-        fields = ('id', 'flow_uuid', 'title', 'org', 'category')
+        fields = ('id', 'flow_uuid', 'title', 'org', 'questions', 'category', 'created_on')
 
 
 class NewsItemReadSerializer(serializers.ModelSerializer):
@@ -72,7 +85,7 @@ class NewsItemReadSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = NewsItem
-        fields = ('id', 'short_description', 'category', 'title', 'description', 'link', 'org')
+        fields = ('id', 'short_description', 'category', 'title', 'description', 'link', 'org', 'created_on')
 
     def get_short_description(self, obj):
         return obj.short_description()
@@ -83,7 +96,7 @@ class VideoReadSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Video
-        fields = ('id', 'category', 'title', 'description', 'video_id', 'org')
+        fields = ('id', 'category', 'title', 'description', 'video_id', 'org', 'created_on')
 
 
 class ImageReadSerializer(serializers.ModelSerializer):
@@ -91,7 +104,7 @@ class ImageReadSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Image
-        fields = ('id', 'image_url', 'image_type', 'org', 'name',)
+        fields = ('id', 'image_url', 'image_type', 'org', 'name', 'created_on')
 
     def get_image_url(self, obj):
         return generate_absolute_url_from_file(self.context['request'], obj.image)

--- a/ureport/api/tests.py
+++ b/ureport/api/tests.py
@@ -158,10 +158,13 @@ class UreportAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         poll = self.reg_poll
         category = response.data.pop('category')
+        print response.data
         self.assertDictEqual(response.data, dict(id=poll.pk,
                                                  flow_uuid=poll.flow_uuid,
                                                  title=poll.title,
                                                  org=poll.org_id,
+                                                 created_on=poll.created_on.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                                                 questions=list(poll.questions.all())
                                                  ))
         self.assertDictEqual(dict(category), dict(OrderedDict(name=poll.category.name,
                                                   image_url=CategoryReadSerializer().
@@ -188,7 +191,8 @@ class UreportAPITests(APITestCase):
                                                  title=news.title,
                                                  description=news.description,
                                                  link=news.link,
-                                                 org=news.org_id))
+                                                 org=news.org_id,
+                                                 created_on=news.created_on.strftime('%Y-%m-%dT%H:%M:%S.%fZ')))
         self.assertDictEqual(dict(category), dict(name=news.category.name,
                                                   image_url=CategoryReadSerializer().get_image_url(news.category)))
 
@@ -212,7 +216,8 @@ class UreportAPITests(APITestCase):
                                                  title=video.title,
                                                  video_id=video.video_id,
                                                  description=video.description,
-                                                 org=video.org_id))
+                                                 org=video.org_id,
+                                                 created_on=video.created_on.strftime('%Y-%m-%dT%H:%M:%S.%fZ')))
         self.assertDictEqual(dict(category), dict(name=video.category.name,
                                                   image_url=CategoryReadSerializer().get_image_url(video.category)))
 
@@ -240,6 +245,7 @@ class UreportAPITests(APITestCase):
                                                  featured=story.featured,
                                                  tags=story.tags,
                                                  images=StoryReadSerializer().get_images(story),
-                                                 org=story.org_id))
+                                                 org=story.org_id,
+                                                 created_on=story.created_on.strftime('%Y-%m-%dT%H:%M:%S.%fZ')))
         self.assertDictEqual(dict(category), dict(name=story.category.name,
                                                   image_url=CategoryReadSerializer().get_image_url(story.category)))

--- a/ureport/api/views.py
+++ b/ureport/api/views.py
@@ -2,10 +2,10 @@ from dash.orgs.models import Org
 from dash.stories.models import Story
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from ureport.api.serializers import PollReadSerializer, NewsItemReadSerializer, VideoReadSerializer, ImageReadSerializer, \
-    OrgReadSerializer, StoryReadSerializer
+    OrgReadSerializer, StoryReadSerializer, PollQuestionReadSerializer
 from ureport.assets.models import Image
 from ureport.news.models import NewsItem, Video
-from ureport.polls.models import Poll
+from ureport.polls.models import Poll, PollQuestion
 
 __author__ = 'kenneth'
 
@@ -81,7 +81,7 @@ class OrgDetails(RetrieveAPIView):
 
 class BaseListAPIView(ListAPIView):
     def get_queryset(self):
-        q = self.model.objects.filter(is_active=True)
+        q = self.model.objects.filter(is_active=True).order_by('-created_on')
         if self.kwargs.get('org', None):
             q = q.filter(org_id=self.kwargs.get('org'))
         return q
@@ -106,7 +106,7 @@ class PollList(BaseListAPIView):
 
         GET /api/v1/polls/org/1/
 
-    Response is the list of polls on the flow, most recent first:
+    Response is the list of polls, most recent first:
 
         {
             "count": 389,

--- a/ureport/api/views.py
+++ b/ureport/api/views.py
@@ -114,14 +114,35 @@ class PollList(BaseListAPIView):
             "previous": null,
             "results": [
             {
-                "id": 1,
-                "flow_uuid": "a22991df-6d84-4b94-b6da-7b00086a2023",
-                "title": "test",
+                "id": 2,
+                "flow_uuid": "a497ba0f-6b58-4bed-ba52-05c3f40403e2",
+                "title": "Food Poll",
                 "org": 1,
+                "questions": [
+                    {
+                        "title": "Are you hungry",
+                        "ruleset_uuid": "ea74b2c2-7425-443a-97cb-331d4e11abb6",
+                        "is_open_ended": false,
+                        "total_summary_data": {}
+                    },
+                    {
+                        "title": "What would you like to eat",
+                        "ruleset_uuid": "66e08f93-cdff-4dbc-bd02-c746770a4fac",
+                        "is_open_ended": false,
+                        "total_summary_data": {}
+                    },
+                    {
+                        "title": "Where would you like to eat",
+                        "ruleset_uuid": "e31755dd-c61a-460c-acaf-0eeee1ce0107",
+                        "is_open_ended": false,
+                        "total_summary_data": {}
+                    }
+                ],
                 "category": {
-                    "image_url": "http://fake.ureport.in/media/categories/StraightOuttaSomewhere_2.jpg",
+                    "image_url": "http://test.ureport.in/media/categories/StraightOuttaSomewhere_2.jpg",
                     "name": "tests"
-                }
+                },
+                "created_on": "2015-09-02T08:53:30.313251Z"
             },
             ...
         }
@@ -149,14 +170,35 @@ class PollDetails(RetrieveAPIView):
     Response is a single poll with that ID:
 
         {
-            "id": 1,
-            "flow_uuid": "a22991df-6d84-4b94-b6da-7b00086a2023",
-            "title": "test",
+            "id": 2,
+            "flow_uuid": "a497ba0f-6b58-4bed-ba52-05c3f40403e2",
+            "title": "Food Poll",
             "org": 1,
+            "questions": [
+                {
+                    "title": "Are you hungry",
+                    "ruleset_uuid": "ea74b2c2-7425-443a-97cb-331d4e11abb6",
+                    "is_open_ended": false,
+                    "total_summary_data": {}
+                },
+                {
+                    "title": "What would you like to eat",
+                    "ruleset_uuid": "66e08f93-cdff-4dbc-bd02-c746770a4fac",
+                    "is_open_ended": false,
+                    "total_summary_data": {}
+                },
+                {
+                    "title": "Where would you like to eat",
+                    "ruleset_uuid": "e31755dd-c61a-460c-acaf-0eeee1ce0107",
+                    "is_open_ended": false,
+                    "total_summary_data": {}
+                }
+            ],
             "category": {
-                "image_url": "http://fake.ureport.in/media/categories/StraightOuttaSomewhere_2.jpg",
+                "image_url": "http://test.ureport.in/media/categories/StraightOuttaSomewhere_2.jpg",
                 "name": "tests"
-            }
+            },
+            "created_on": "2015-09-02T08:53:30.313251Z"
         }
     """
     serializer_class = PollReadSerializer
@@ -177,30 +219,42 @@ class FeaturedPollList(BaseListAPIView):
     An empty list is returned if there are no polls with questions.
 
         {
-            "count": 2,
-            "next": "/api/v1/polls/org/1/featured",
+            "count": 389,
+            "next": "/api/v1/polls/org/1/?page=2",
             "previous": null,
             "results": [
             {
-                "id": 1,
-                "flow_uuid": "a22991df-6d84-4b94-b6da-7b00086a2023",
-                "title": "test",
-                "org": 1,
-                "category": {
-                    "image_url": "http://fake.ureport.in/media/categories/StraightOuttaSomewhere_2.jpg",
-                    "name": "tests"
-                }
-            },
-            {
                 "id": 2,
-                "flow_uuid": "8d82bac4-0f11-4dfa-822b-50a4d76c8998",
-                "title": "the featured poll",
+                "flow_uuid": "a497ba0f-6b58-4bed-ba52-05c3f40403e2",
+                "title": "Food Poll",
                 "org": 1,
+                "questions": [
+                    {
+                        "title": "Are you hungry",
+                        "ruleset_uuid": "ea74b2c2-7425-443a-97cb-331d4e11abb6",
+                        "is_open_ended": false,
+                        "total_summary_data": {}
+                    },
+                    {
+                        "title": "What would you like to eat",
+                        "ruleset_uuid": "66e08f93-cdff-4dbc-bd02-c746770a4fac",
+                        "is_open_ended": false,
+                        "total_summary_data": {}
+                    },
+                    {
+                        "title": "Where would you like to eat",
+                        "ruleset_uuid": "e31755dd-c61a-460c-acaf-0eeee1ce0107",
+                        "is_open_ended": false,
+                        "total_summary_data": {}
+                    }
+                ],
                 "category": {
-                    "image_url": null,
-                    "name": "some category name"
-                }
-            }
+                    "image_url": "http://test.ureport.in/media/categories/StraightOuttaSomewhere_2.jpg",
+                    "name": "tests"
+                },
+                "created_on": "2015-09-02T08:53:30.313251Z"
+            },
+            ...
         }
     """
     serializer_class = PollReadSerializer


### PR DESCRIPTION
Although most of this derivable from the flow_uuid, the team working on the app think that it is more efficient and convenient for them to get the cached `get_total_summary_data` from Ureport. That is the main reason I have added questions to this endpoint. Please check it out and let me know what you think. 

* Overrode the drf template for the browsable API. 
* Added time stamps on Polls, News, Stories, Assets endpoints
* Added questions to polls