### PR TITLE
Adjusting readme to create more platform consistent instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ Install dependencies
 ```
 % virtualenv env
 % source env/bin/activate
-% pip install -r pip-requires.txt
+% pip install -r pip-freeze.txt
 ```
 
 Link up a settings file (you'll need to create the postgres db first, username: 'ureport' password: 'nyaruka')
 ```
-% ln -s ureport/settings.py.postgres ureport/settings.py
+% cp ureport/settings.py.postgres ureport/settings.py
 ```
 
 Sync the database, add all our models and create our superuser


### PR DESCRIPTION
Making simple changes in the README so that issues like #98 don't appear as often as they do.
- Change Install dependencies from `pip install -r pip-requires.txt` to `pip install pip-freeze.txt`
- Change creating settings file from creating sym link to creating copy of file. symbolics links don't seem to have consistent behaviour on different filesystems or platforms
