### PR TITLE
Expose Org stats in api

### DIFF
--- a/ureport/api/serializers.py
+++ b/ureport/api/serializers.py
@@ -59,7 +59,7 @@ class OrgReadSerializer(serializers.ModelSerializer):
         return obj.get_registration_stats()
 
     def get_occupation_stats(self, obj):
-        obj.get_occupation_stats()
+        return obj.get_occupation_stats()
 
 
 class StoryReadSerializer(serializers.ModelSerializer):

--- a/ureport/api/serializers.py
+++ b/ureport/api/serializers.py
@@ -1,3 +1,4 @@
+import json
 from dash.categories.models import Category
 from dash.orgs.models import Org
 from dash.stories.models import Story
@@ -53,13 +54,13 @@ class OrgReadSerializer(serializers.ModelSerializer):
         return obj.get_gender_stats()
 
     def get_age_stats(self, obj):
-        return obj.get_age_stats()
+        return json.loads(obj.get_age_stats())
 
     def get_registration_stats(self, obj):
-        return obj.get_registration_stats()
+        return json.loads(obj.get_registration_stats())
 
     def get_occupation_stats(self, obj):
-        return obj.get_occupation_stats()
+        return json.loads(obj.get_occupation_stats())
 
 
 class StoryReadSerializer(serializers.ModelSerializer):

--- a/ureport/api/serializers.py
+++ b/ureport/api/serializers.py
@@ -34,15 +34,32 @@ class CategoryReadSerializer(serializers.ModelSerializer):
 
 class OrgReadSerializer(serializers.ModelSerializer):
     logo_url = SerializerMethodField()
+    gender_stats = SerializerMethodField()
+    age_stats = SerializerMethodField()
+    registration_stats = SerializerMethodField()
+    occupation_stats = SerializerMethodField()
 
     class Meta:
         model = Org
-        fields = ('id', 'logo_url', 'name', 'language', 'subdomain', 'domain', 'timezone', )
+        fields = ('id', 'logo_url', 'name', 'language', 'subdomain', 'domain', 'timezone', 'gender_stats', 'age_stats',
+                  'registration_stats', 'occupation_stats',)
 
     def get_logo_url(self, obj):
         if obj.logo:
             return generate_absolute_url_from_file(self.context['request'], obj.logo)
         return None
+
+    def get_gender_stats(self, obj):
+        return obj.get_gender_stats()
+
+    def get_age_stats(self, obj):
+        return obj.get_age_stats()
+
+    def get_registration_stats(self, obj):
+        return obj.get_registration_stats()
+
+    def get_occupation_stats(self, obj):
+        obj.get_occupation_stats()
 
 
 class StoryReadSerializer(serializers.ModelSerializer):

--- a/ureport/api/serializers.py
+++ b/ureport/api/serializers.py
@@ -39,11 +39,12 @@ class OrgReadSerializer(serializers.ModelSerializer):
     age_stats = SerializerMethodField()
     registration_stats = SerializerMethodField()
     occupation_stats = SerializerMethodField()
+    reporters_count = SerializerMethodField()
 
     class Meta:
         model = Org
         fields = ('id', 'logo_url', 'name', 'language', 'subdomain', 'domain', 'timezone', 'gender_stats', 'age_stats',
-                  'registration_stats', 'occupation_stats',)
+                  'registration_stats', 'occupation_stats', 'reporters_count')
 
     def get_logo_url(self, obj):
         if obj.logo:
@@ -61,6 +62,9 @@ class OrgReadSerializer(serializers.ModelSerializer):
 
     def get_occupation_stats(self, obj):
         return json.loads(obj.get_occupation_stats())
+
+    def get_reporters_count(self, obj):
+        return obj.get_reporters_count()
 
 
 class StoryReadSerializer(serializers.ModelSerializer):

--- a/ureport/api/tests.py
+++ b/ureport/api/tests.py
@@ -124,10 +124,10 @@ class UreportAPITests(APITestCase):
                                                  subdomain=org.subdomain,
                                                  domain=org.domain,
                                                  timezone=org.timezone))
-        self.assertEquals(gender_stats, org.get_gender_stats)
-        self.assertEquals(age_stats, org.get_age_stats)
-        self.assertEquals(registration_stats, org.get_registration_stats)
-        self.assertEquals(occupation_stats, org.get_occupation_stats)
+        self.assertEquals(gender_stats, org.get_gender_stats())
+        self.assertEquals(age_stats, org.get_age_stats())
+        self.assertEquals(registration_stats, org.get_registration_stats())
+        self.assertEquals(occupation_stats, org.get_occupation_stats())
 
     def test_polls_by_org_list(self):
         url = '/api/v1/polls/org/%d/' % self.uganda.pk

--- a/ureport/api/tests.py
+++ b/ureport/api/tests.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+import json
 from random import randint
 from dash.categories.models import Category
 from dash.orgs.models import Org
@@ -125,9 +126,9 @@ class UreportAPITests(APITestCase):
                                                  domain=org.domain,
                                                  timezone=org.timezone))
         self.assertEquals(gender_stats, org.get_gender_stats())
-        self.assertEquals(age_stats, org.get_age_stats())
-        self.assertEquals(registration_stats, org.get_registration_stats())
-        self.assertEquals(occupation_stats, org.get_occupation_stats())
+        self.assertEquals(age_stats, json.loads(org.get_age_stats()))
+        self.assertEquals(registration_stats, json.loads(org.get_registration_stats()))
+        self.assertEquals(occupation_stats, json.loads(org.get_occupation_stats()))
 
     def test_polls_by_org_list(self):
         url = '/api/v1/polls/org/%d/' % self.uganda.pk

--- a/ureport/api/tests.py
+++ b/ureport/api/tests.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 import json
 from random import randint
-from time import timezone
+from django.utils import timezone
 from dash.categories.models import Category
 from dash.orgs.models import Org
 from dash.stories.models import Story
@@ -173,8 +173,8 @@ class UreportAPITests(APITestCase):
                                             male_count=3, male_percentage="60%"))
 
         age_stats = response.data.pop('age_stats')
-        self.assertEqual(age_stats, json.dumps([dict(name='0-10', y=30), dict(name='10-20', y=50),
-                                                dict(name='40-50', y=20)]))
+        self.assertEqual(age_stats, [dict(name='0-10', y=30), dict(name='10-20', y=50),
+                                                dict(name='40-50', y=20)])
 
         reporters_count = response.data.pop('reporters_count')
         self.assertEqual(reporters_count, 5)

--- a/ureport/api/tests.py
+++ b/ureport/api/tests.py
@@ -113,6 +113,10 @@ class UreportAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         org = self.uganda
         logo_url = generate_absolute_url_from_file(response, org.logo) if org.logo else None
+        gender_stats = response.data.pop('gender_stats')
+        age_stats = response.data.pop('age_stats')
+        registration_stats = response.data.pop('registration_stats')
+        occupation_stats = response.data.pop('occupation_stats')
         self.assertDictEqual(response.data, dict(id=org.pk,
                                                  logo_url=logo_url,
                                                  name=org.name,
@@ -120,6 +124,10 @@ class UreportAPITests(APITestCase):
                                                  subdomain=org.subdomain,
                                                  domain=org.domain,
                                                  timezone=org.timezone))
+        self.assertEquals(gender_stats, org.get_gender_stats)
+        self.assertEquals(age_stats, org.get_age_stats)
+        self.assertEquals(registration_stats, org.get_registration_stats)
+        self.assertEquals(occupation_stats, org.get_occupation_stats)
 
     def test_polls_by_org_list(self):
         url = '/api/v1/polls/org/%d/' % self.uganda.pk

--- a/ureport/api/views.py
+++ b/ureport/api/views.py
@@ -46,14 +46,14 @@ class OrgList(ListAPIView):
                 "domain": "ureport.in",
                 "timezone": "Africa/Kampala"
                 "gender_stats": {
-                "female_count": 0,
-                "male_percentage": "---",
-                "female_percentage": "---",
-                "male_count": 0
+                    "female_count": 0,
+                    "male_percentage": "---",
+                    "female_percentage": "---",
+                    "male_count": 0
                 },
-                "age_stats": "[]",
-                "registration_stats": "[{\"count\": 0, \"label\": \"07/06/15\"}]",
-                "occupation_stats": null
+                "age_stats": [],
+                "registration_stats": [{"count": 0, "label": "07/06/15"}],
+                "occupation_stats": []
             },
             ...
         }
@@ -83,14 +83,14 @@ class OrgDetails(RetrieveAPIView):
             "domain": "ureport.in",
             "timezone": "Africa/Kampala"
             "gender_stats": {
-                "female_count": 0,
-                "male_percentage": "---",
-                "female_percentage": "---",
-                "male_count": 0
-            },
-            "age_stats": "[]",
-            "registration_stats": "[{\"count\": 0, \"label\": \"07/06/15\"}, {\"count\": 0, \"label\": \"07/13/15\"}, {\"count\": 0, \"label\": \"07/20/15\"}, {\"count\": 0, \"label\": \"07/27/15\"}, {\"count\": 0, \"label\": \"08/03/15\"}, {\"count\": 0, \"label\": \"08/10/15\"}, {\"count\": 0, \"label\": \"08/17/15\"}, {\"count\": 0, \"label\": \"08/24/15\"}, {\"count\": 0, \"label\": \"08/31/15\"}, {\"count\": 0, \"label\": \"09/07/15\"}, {\"count\": 0, \"label\": \"09/14/15\"}, {\"count\": 0, \"label\": \"09/21/15\"}, {\"count\": 0, \"label\": \"09/28/15\"}, {\"count\": 0, \"label\": \"10/05/15\"}, {\"count\": 0, \"label\": \"10/12/15\"}, {\"count\": 0, \"label\": \"10/19/15\"}, {\"count\": 0, \"label\": \"10/26/15\"}, {\"count\": 0, \"label\": \"11/02/15\"}, {\"count\": 0, \"label\": \"11/09/15\"}, {\"count\": 0, \"label\": \"11/16/15\"}, {\"count\": 0, \"label\": \"11/23/15\"}, {\"count\": 0, \"label\": \"11/30/15\"}, {\"count\": 0, \"label\": \"12/07/15\"}, {\"count\": 0, \"label\": \"12/14/15\"}, {\"count\": 0, \"label\": \"12/21/15\"}, {\"count\": 0, \"label\": \"12/28/15\"}, {\"count\": 0, \"label\": \"01/04/16\"}]",
-            "occupation_stats": null
+                    "female_count": 0,
+                    "male_percentage": "---",
+                    "female_percentage": "---",
+                    "male_count": 0
+                },
+            "age_stats": [],
+            "registration_stats": [{"count": 0, "label": "07/06/15"}],
+            "occupation_stats": []
         }
     """
     serializer_class = OrgReadSerializer

--- a/ureport/api/views.py
+++ b/ureport/api/views.py
@@ -45,6 +45,15 @@ class OrgList(ListAPIView):
                 "subdomain": "test",
                 "domain": "ureport.in",
                 "timezone": "Africa/Kampala"
+                "gender_stats": {
+                "female_count": 0,
+                "male_percentage": "---",
+                "female_percentage": "---",
+                "male_count": 0
+                },
+                "age_stats": "[]",
+                "registration_stats": "[{\"count\": 0, \"label\": \"07/06/15\"}]",
+                "occupation_stats": null
             },
             ...
         }
@@ -73,6 +82,15 @@ class OrgDetails(RetrieveAPIView):
             "subdomain": "test",
             "domain": "ureport.in",
             "timezone": "Africa/Kampala"
+            "gender_stats": {
+                "female_count": 0,
+                "male_percentage": "---",
+                "female_percentage": "---",
+                "male_count": 0
+            },
+            "age_stats": "[]",
+            "registration_stats": "[{\"count\": 0, \"label\": \"07/06/15\"}, {\"count\": 0, \"label\": \"07/13/15\"}, {\"count\": 0, \"label\": \"07/20/15\"}, {\"count\": 0, \"label\": \"07/27/15\"}, {\"count\": 0, \"label\": \"08/03/15\"}, {\"count\": 0, \"label\": \"08/10/15\"}, {\"count\": 0, \"label\": \"08/17/15\"}, {\"count\": 0, \"label\": \"08/24/15\"}, {\"count\": 0, \"label\": \"08/31/15\"}, {\"count\": 0, \"label\": \"09/07/15\"}, {\"count\": 0, \"label\": \"09/14/15\"}, {\"count\": 0, \"label\": \"09/21/15\"}, {\"count\": 0, \"label\": \"09/28/15\"}, {\"count\": 0, \"label\": \"10/05/15\"}, {\"count\": 0, \"label\": \"10/12/15\"}, {\"count\": 0, \"label\": \"10/19/15\"}, {\"count\": 0, \"label\": \"10/26/15\"}, {\"count\": 0, \"label\": \"11/02/15\"}, {\"count\": 0, \"label\": \"11/09/15\"}, {\"count\": 0, \"label\": \"11/16/15\"}, {\"count\": 0, \"label\": \"11/23/15\"}, {\"count\": 0, \"label\": \"11/30/15\"}, {\"count\": 0, \"label\": \"12/07/15\"}, {\"count\": 0, \"label\": \"12/14/15\"}, {\"count\": 0, \"label\": \"12/21/15\"}, {\"count\": 0, \"label\": \"12/28/15\"}, {\"count\": 0, \"label\": \"01/04/16\"}]",
+            "occupation_stats": null
         }
     """
     serializer_class = OrgReadSerializer


### PR DESCRIPTION
There is need to expose the stats that are shown on /ureporters page in API.

Writing tests for this is a bit challenging since the results for these are not generated but read from cache instead. If anyone has any idea has any ideas on how I can go about testing these, I will appreciate very much.