### PR TITLE
Synchronization of removed contacts on RapidPRO

### DIFF
--- a/ureport/contacts/models.py
+++ b/ureport/contacts/models.py
@@ -249,20 +249,19 @@ class Contact(models.Model):
 
         return seen_uuids
 
-	@classmethod
-	def sync_contacts_removed(cls, org, temba_contacts):
-		ureport_contacts = cls.objects.all()
+    @classmethod
+    def sync_contacts_removed(cls, org, temba_contacts):
+        ureport_contacts = cls.objects.all()
 
-		contacts_removed = []
+        contacts_removed = []
 
-		for ureport_contact in ureport_contacts:
+        for ureport_contact in ureport_contacts:
             if ureport_contact.uuid not in temba_contacts:
                 ureport_contact.delete()
                 ReportersCounter(org=org, type='total-reporters', count=-1)
                 contacts_removed.append(ureport_contact)
 
         return contacts_removed
-
 
 class ReportersCounter(models.Model):
 

--- a/ureport/contacts/models.py
+++ b/ureport/contacts/models.py
@@ -249,6 +249,20 @@ class Contact(models.Model):
 
         return seen_uuids
 
+	@classmethod
+	def sync_contacts_removed(cls, org, temba_contacts):
+		ureport_contacts = cls.objects.all()
+
+		contacts_removed = []
+
+		for ureport_contact in ureport_contacts:
+            if ureport_contact.uuid not in temba_contacts:
+                ureport_contact.delete()
+                ReportersCounter(org=org, type='total-reporters', count=-1)
+                contacts_removed.append(ureport_contact)
+
+        return contacts_removed
+
 
 class ReportersCounter(models.Model):
 

--- a/ureport/contacts/models.py
+++ b/ureport/contacts/models.py
@@ -254,7 +254,7 @@ class Contact(models.Model):
 
         contacts_removed = []
         try:
-            contacts_removed = Contact.objects.all().exclude(uuid__in=temba_contacts)
+            contacts_removed = Contact.objects.filter(org=org).exclude(uuid__in=temba_contacts)
 
             for contact in contacts_removed:
                 contact.delete()

--- a/ureport/contacts/models.py
+++ b/ureport/contacts/models.py
@@ -260,7 +260,7 @@ class Contact(models.Model):
                 contact.delete()
                 ReportersCounter(org=org, type='total-reporters', count=-1)
 
-        except:
+        except:  # pragma: no cover
             import traceback
             traceback.print_exc()
 

--- a/ureport/contacts/tasks.py
+++ b/ureport/contacts/tasks.py
@@ -50,7 +50,8 @@ def fetch_contacts_task(org_id=None, fetch_all=False):
 
                     Boundary.get_boundaries(org)
                     ContactField.get_contact_fields(org)
-                    Contact.fetch_contacts(org, after=after)
+                    contacts = Contact.fetch_contacts(org, after=after)
+                    Contact.sync_contacts_removed(org, contacts)
 
                     print "Task: fetch_contacts for %s took %ss" % (org.name, time.time() - start)
 

--- a/ureport/contacts/tasks.py
+++ b/ureport/contacts/tasks.py
@@ -51,7 +51,7 @@ def fetch_contacts_task(org_id=None, fetch_all=False):
                     Boundary.get_boundaries(org)
                     ContactField.get_contact_fields(org)
                     contacts = Contact.fetch_contacts(org, after=after)
-                    Contact.sync_contacts_removed(org, contacts)
+                    Contact.sync_contacts_removed(org, contacts) 
 
                     print "Task: fetch_contacts for %s took %ss" % (org.name, time.time() - start)
 

--- a/ureport/contacts/tasks.py
+++ b/ureport/contacts/tasks.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 
 @app.task(name='contacts.fetch_contacts_task')
 def fetch_contacts_task(org_id=None, fetch_all=False):
-
     r = get_redis_connection()
 
     key = 'fetch_contacts'
@@ -51,7 +50,9 @@ def fetch_contacts_task(org_id=None, fetch_all=False):
                     Boundary.get_boundaries(org)
                     ContactField.get_contact_fields(org)
                     contacts = Contact.fetch_contacts(org, after=after)
-                    Contact.sync_contacts_removed(org, contacts) 
+
+                    if after is None:
+                        Contact.sync_contacts_removed(org, contacts)
 
                     print "Task: fetch_contacts for %s took %ss" % (org.name, time.time() - start)
 
@@ -59,5 +60,3 @@ def fetch_contacts_task(org_id=None, fetch_all=False):
                     import traceback
                     traceback.print_exc()
                     logger.exception("Error fetching contacts: %s" % str(e))
-
-


### PR DESCRIPTION
This update fixes the synchronization of removed contacts on RapidPRO side. The error occurs when someone deletes a contact on RapidPRO or from the main U-Reporters group, in this case the amount of U-Reporters on the RapidPRO keeps different from U-Report dashboard.