### PR TITLE
Add a way to deactivate the contacts that opted out on rapidpro

### DIFF
--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -5,7 +5,7 @@ boto==2.36.0
 celery==3.1.19
 celery-with-redis==3.0
 coverage==3.7.1
--e git+https://github.com/rapidpro/dash.git@e2f81cde5f17ed2528e4a2c13b382af672ccd86c#egg=dash-master
+-e git+https://github.com/rapidpro/dash.git@a6b7107b26f76747321fed617cf5ca5d5baa23b3#egg=dash-master
 dj-database-url==0.3.0
 Django==1.8.4
 django-appconf==1.0.1

--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -5,7 +5,7 @@ boto==2.36.0
 celery==3.1.19
 celery-with-redis==3.0
 coverage==3.7.1
--e git+https://github.com/rapidpro/dash.git@6806443e5f165c85df99e6f667d48e66751eaf05#egg=dash-master
+-e git+https://github.com/rapidpro/dash.git@e2f81cde5f17ed2528e4a2c13b382af672ccd86c#egg=dash-master
 dj-database-url==0.3.0
 Django==1.8.4
 django-appconf==1.0.1

--- a/ureport/contacts/migrations/0009_contact_is_active.py
+++ b/ureport/contacts/migrations/0009_contact_is_active.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0008_auto_20160129_0957'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='contact',
+            name='is_active',
+            field=models.BooleanField(default=True),
+        ),
+    ]

--- a/ureport/contacts/migrations/0010_contact_triggers.py
+++ b/ureport/contacts/migrations/0010_contact_triggers.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+# language=SQL
+TRIGGER_SQL = """
+-----------------------------------------------------------------------------
+-- Increment or decrement the reporters count on counter of given type
+-----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION
+  ureport_insert_reporters_counter(_org_id INT, _type VARCHAR, _count INT)
+RETURNS VOID AS $$
+BEGIN
+  INSERT INTO contacts_reporterscounter("org_id", "type", "count") VALUES(_org_id, _type, _count);
+  PERFORM ureport_maybe_squash_reporterscounters(_org_id, _type);
+END;
+$$ LANGUAGE plpgsql;
+-----------------------------------------------------------------------------
+-- Every 100 inserts or so this will squash the counters by gathering
+-----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION
+  ureport_maybe_squash_reporterscounters(_org_id INT, _type VARCHAR)
+RETURNS VOID AS $$
+BEGIN
+  IF RANDOM() < .01 THEN
+    WITH deleted as (DELETE FROM contacts_reporterscounter
+      WHERE "org_id" = _org_id AND "type" = _type
+      RETURNING "count")
+      INSERT INTO contacts_reporterscounter("org_id", "type", "count")
+      VALUES (_org_id, _type ,GREATEST(0, (SELECT SUM("count") FROM deleted)));
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+-----------------------------------------------------------------------------
+-- Increment counters for a contact
+-----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION ureport_increment_counter_for_contact(_contact contacts_contact, _add BOOLEAN)
+RETURNS VOID AS $$
+DECLARE
+  _count INT;
+BEGIN
+  IF _add THEN
+    _count = 1;
+  ELSE
+    _count = -1;
+  END IF;
+  -- If we have a org, increment all reporters counters for its values
+  IF _contact.org_id IS NOT NULL THEN
+    PERFORM ureport_insert_reporters_counter(_contact.org_id, 'total-reporters', _count);
+    IF _contact.gender IS NOT NULL THEN
+      PERFORM ureport_insert_reporters_counter(_contact.org_id, CONCAT('gender:', LOWER(_contact.gender)), _count);
+    END IF;
+    IF _contact.born IS NOT NULL THEN
+      PERFORM ureport_insert_reporters_counter(_contact.org_id, CONCAT('born:', LOWER(CAST(_contact.born AS VARCHAR ))), _count);
+    END IF;
+    IF _contact.occupation IS NOT NULL THEN
+      PERFORM ureport_insert_reporters_counter(_contact.org_id, CONCAT('occupation:', LOWER(_contact.occupation)), _count);
+    END IF;
+    IF _contact.registered_on IS NOT NULL THEN
+      PERFORM ureport_insert_reporters_counter(_contact.org_id, CONCAT('registered_on:', DATE(_contact.registered_on)), _count);
+    END IF;
+    IF _contact.state IS NOT NULL THEN
+      PERFORM ureport_insert_reporters_counter(_contact.org_id, CONCAT('state:', UPPER(_contact.state)), _count);
+    END IF;
+    IF _contact.district IS NOT NULL THEN
+      PERFORM ureport_insert_reporters_counter(_contact.org_id, CONCAT('district:', UPPER(_contact.district)), _count);
+    END IF;
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ureport_adjust_counter_for_contact(_new_contact contacts_contact, _old_contact contacts_contact)
+RETURNS VOID AS $$
+BEGIN
+  -- no org id, decrement all reporters counters for its previous values
+  IF _new_contact.org_id IS NULL THEN
+    PERFORM ureport_increment_counter_for_contact(_old_contact, FALSE);
+
+  ELSIF _new_contact.is_active != _old_contact.is_active THEN
+    PERFORM ureport_increment_counter_for_contact(_old_contact, _new_contact.is_active);
+
+  ELSIF _new_contact.org_id = _old_contact.org_id THEN
+
+    IF _new_contact.gender != _old_contact.gender THEN
+      PERFORM ureport_insert_reporters_counter(_old_contact.org_id, CONCAT('gender:', LOWER(_old_contact.gender)), -1);
+      PERFORM ureport_insert_reporters_counter(_new_contact.org_id, CONCAT('gender:', LOWER(_new_contact.gender)), 1);
+    END IF;
+
+    IF _new_contact.born != _old_contact.born THEN
+      PERFORM ureport_insert_reporters_counter(_old_contact.org_id, CONCAT('born:', LOWER(CAST(_old_contact.born AS VARCHAR ))), -1);
+      PERFORM ureport_insert_reporters_counter(_new_contact.org_id, CONCAT('born:', LOWER(CAST(_new_contact.born AS VARCHAR ))), 1);
+    END IF;
+
+    IF _new_contact.occupation != _old_contact.occupation THEN
+      PERFORM ureport_insert_reporters_counter(_old_contact.org_id, CONCAT('occupation:', LOWER(_old_contact.occupation)), -1);
+      PERFORM ureport_insert_reporters_counter(_new_contact.org_id, CONCAT('occupation:', LOWER(_new_contact.occupation)), 1);
+    END IF;
+
+    IF _new_contact.registered_on != _old_contact.registered_on THEN
+      PERFORM ureport_insert_reporters_counter(_old_contact.org_id, CONCAT('registered_on:', DATE(_old_contact.registered_on)), -1);
+      PERFORM ureport_insert_reporters_counter(_new_contact.org_id, CONCAT('registered_on:', DATE(_new_contact.registered_on)), 1);
+    END IF;
+
+    IF _new_contact.state != _old_contact.state THEN
+      PERFORM ureport_insert_reporters_counter(_old_contact.org_id, CONCAT('state:', UPPER(_old_contact.state)), -1);
+      PERFORM ureport_insert_reporters_counter(_new_contact.org_id, CONCAT('state:', UPPER(_new_contact.state)), 1);
+    END IF;
+
+    IF _new_contact.district != _old_contact.district THEN
+      PERFORM ureport_insert_reporters_counter(_old_contact.org_id, CONCAT('district:', UPPER(_old_contact.district)), -1);
+      PERFORM ureport_insert_reporters_counter(_new_contact.org_id, CONCAT('district:', UPPER(_new_contact.district)), 1);
+    END IF;
+  END IF;
+
+END;
+$$ LANGUAGE plpgsql;
+
+
+-----------------------------------------------------------------------------
+-- Updates our reporters counters
+-----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION ureport_update_counters() RETURNS TRIGGER AS $$
+BEGIN
+
+  -- Contact being created, increment counters for contact NEW
+  IF TG_OP = 'INSERT' THEN
+    PERFORM ureport_increment_counter_for_contact(NEW, TRUE);
+  ELSIF TG_OP = 'UPDATE' THEN
+    -- If a contact is changed, adjust the counters
+    PERFORM ureport_adjust_counter_for_contact(NEW, OLD);
+  -- Contact is being deleted
+  ELSIF TG_OP = 'DELETE' THEN
+    -- A contact is deleted, decrement all reporters counters for its values
+    PERFORM ureport_increment_counter_for_contact(OLD, FALSE);
+  -- Contacts table is being truncated
+  ELSIF TG_OP = 'TRUNCATE' THEN
+   -- Clear all counters
+   TRUNCATE contacts_reporterscounter;
+  END IF;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+DROP TRIGGER IF EXISTS ureport_when_contacts_update_then_update_counters on contacts_contact;
+CREATE TRIGGER ureport_when_contacts_update_then_update_counters
+  AFTER INSERT OR DELETE OR UPDATE ON contacts_contact
+  FOR EACH ROW EXECUTE PROCEDURE ureport_update_counters();
+DROP TRIGGER IF EXISTS ureport_when_contacts_truncate_then_update_counters ON contacts_contact;
+CREATE TRIGGER ureport_when_contacts_truncate_then_update_counters
+  AFTER TRUNCATE ON contacts_contact
+  EXECUTE PROCEDURE ureport_update_counters();
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contacts', '0009_contact_is_active'),
+    ]
+
+    operations = [
+        migrations.RunSQL(TRIGGER_SQL)
+    ]

--- a/ureport/contacts/tasks.py
+++ b/ureport/contacts/tasks.py
@@ -50,7 +50,8 @@ def fetch_contacts_task(org_id=None, fetch_all=False):
 
                     Boundary.get_boundaries(org)
                     ContactField.get_contact_fields(org)
-                    Contact.fetch_contacts(org, after=after)
+                    updated_uuids, removed_uuids = Contact.fetch_contacts(org, after=after)
+                    Contact.deactivate_contacts(org, updated_uuids, removed_uuids, after)
 
                     print "Task: fetch_contacts for %s took %ss" % (org.name, time.time() - start)
 

--- a/ureport/contacts/tests.py
+++ b/ureport/contacts/tests.py
@@ -261,6 +261,42 @@ class ContactTest(DashTest):
                 self.assertTrue('000-001' in seen_uuids)
                 self.assertTrue('000-002' in removed_uuids)
 
+    def test_deactivate_contacts(self):
+        uganda = self.create_org('uganda', self.admin)
+        Contact.get_or_create(self.nigeria, 'uuid-1')
+        Contact.get_or_create(self.nigeria, 'uuid-2')
+        Contact.get_or_create(self.nigeria, 'uuid-3')
+        Contact.get_or_create(uganda, 'uuid-4')
+
+        active_uuids = ['uuid-1']
+        removed_uuids = ['uuid-2']
+
+        Contact.deactivate_contacts(self.nigeria, active_uuids, removed_uuids, after=timezone.now())
+
+        contact1 = Contact.get_or_create(self.nigeria, 'uuid-1')
+        contact2 = Contact.get_or_create(self.nigeria, 'uuid-2')
+        contact3 = Contact.get_or_create(self.nigeria, 'uuid-3')
+        contact4 = Contact.get_or_create(uganda, 'uuid-4')
+
+        self.assertFalse(contact2.is_active)
+        self.assertTrue(contact1.is_active)
+        self.assertTrue(contact3.is_active)
+        self.assertTrue(contact4.is_active)
+
+        Contact.objects.all().update(is_active=True)
+
+        Contact.deactivate_contacts(self.nigeria, active_uuids, removed_uuids, after=None)
+
+        contact1 = Contact.get_or_create(self.nigeria, 'uuid-1')
+        contact2 = Contact.get_or_create(self.nigeria, 'uuid-2')
+        contact3 = Contact.get_or_create(self.nigeria, 'uuid-3')
+        contact4 = Contact.get_or_create(uganda, 'uuid-4')
+
+        self.assertFalse(contact2.is_active)
+        self.assertTrue(contact1.is_active)
+        self.assertFalse(contact3.is_active)
+        self.assertTrue(contact4.is_active)
+
     def test_reporters_counter(self):
         self.assertEqual(ReportersCounter.get_counts(self.nigeria), dict())
         Contact.objects.create(uuid='C-007', org=self.nigeria, gender='M', born=1990, occupation='Student',


### PR DESCRIPTION
- Added a field is_active which defaults to True and turned False if the contact opted out on Rapidpro
- we keep that contact so if we fetch old poll result we can match to it
- Update trigger to adjust the contact for the is_active field, if False remove one from all reporters counts
otherwise add one


