### PR TITLE
update the poll title on poll import and fix to proper handle open en…

### DIFF
--- a/ureport/polls/models.py
+++ b/ureport/polls/models.py
@@ -514,6 +514,9 @@ class Poll(SmartModel):
             if poll.questions.filter(ruleset_uuid=ruleset_uuid).exists():
                 imported_poll = Poll.objects.filter(pk=poll.pk).first()
 
+                if imported_poll:
+                    Poll.objects.filter(pk=poll.pk).update(title=name)
+
         if not imported_poll:
             imported_poll = Poll.objects.create(flow_uuid=uuid, title=name, poll_date=created_on, org=org,
                                                 category=category_obj, created_by=user, modified_by=user)
@@ -523,6 +526,9 @@ class Poll(SmartModel):
 
         # hide all other questions
         PollQuestion.objects.filter(poll=imported_poll).exclude(pk=poll_question.pk).update(is_active=False)
+
+        imported_poll.update_or_create_questions()
+
         return imported_poll
 
     def __unicode__(self):

--- a/ureport/public/tests.py
+++ b/ureport/public/tests.py
@@ -6,6 +6,7 @@ from dash.dashblocks.models import DashBlock, DashBlockType
 import mock
 from urllib import urlencode, quote
 
+from datetime import timedelta
 from django.core.files.images import ImageFile
 from django.core.urlresolvers import reverse
 from django.conf import settings
@@ -696,6 +697,17 @@ class PublicTest(DashTest):
         self.assertEquals(response.context['polls'][0], poll3)
         self.assertEquals(response.context['polls'][1], poll2)
         self.assertEquals(response.context['polls'][2], poll1)
+
+        poll1.poll_date = poll3.poll_date + timedelta(days=1)
+        poll1.save()
+
+        response = self.client.get(polls_url, SERVER_NAME='uganda.ureport.io')
+        self.assertEquals(response.context['polls'][0], poll1)
+        self.assertEquals(response.context['polls'][1], poll3)
+        self.assertEquals(response.context['polls'][2], poll2)
+
+        poll1.poll_date = poll1.created_on
+        poll1.save()
 
         poll3.is_active = False
         poll3.save()

--- a/ureport/public/views.py
+++ b/ureport/public/views.py
@@ -144,7 +144,7 @@ class PollContextMixin(object):
         context['latest_poll'] = main_poll
 
         context['categories'] = Category.objects.filter(org=org, is_active=True).order_by('name')
-        context['polls'] = Poll.get_public_polls(org=org).order_by('-created_on')
+        context['polls'] = Poll.get_public_polls(org=org).order_by('-poll_date')
 
         context['related_stories'] = []
         if main_poll:


### PR DESCRIPTION
- when importing a poll we contact rapidpro to get the flow definition and create the needed response categories so we can decide if a question is open ended or not

- reordered the polls to use the poll date field