### PR TITLE
adjustments to display new poll results faster for big accounts

### DIFF
--- a/ureport/backend/rapidpro.py
+++ b/ureport/backend/rapidpro.py
@@ -444,6 +444,9 @@ class RapidProBackend(BaseBackend):
                     fetch_start = time.time()
                     print "=" * 40
 
+                    if num_synced % 100000 == 0:
+                        poll.rebuild_poll_results_counts()
+
                 # update the time for this poll from which we fetch next time
                 cache.set(Poll.POLL_RESULTS_LAST_PULL_CACHE_KEY % (org.pk, poll.flow_uuid),
                           datetime_to_json_date(now.replace(tzinfo=pytz.utc)), None)

--- a/ureport/contacts/tests.py
+++ b/ureport/contacts/tests.py
@@ -30,6 +30,18 @@ class ContactFieldTest(DashTest):
         # try creating contact from them
         ContactField.objects.create(**kwargs)
 
+    def test_update_or_create_from_temba(self):
+        temba_contact_field = TembaContactField.create(key='foo', label='Bar', value_type='T')
+
+        field = ContactField.update_or_create_from_temba(self.nigeria, temba_contact_field)
+
+        self.assertEqual(field.key, 'foo')
+        self.assertEqual(field.label, 'Bar')
+
+        updated_field = ContactField.update_or_create_from_temba(self.nigeria, temba_contact_field)
+
+        self.assertEqual(field.pk, updated_field.pk)
+
 
 class ContactTest(DashTest):
     def setUp(self):
@@ -137,6 +149,22 @@ class ContactTest(DashTest):
 
         # try creating contact from them
         Contact.objects.create(**kwargs)
+
+    def test_update_or_create_from_temba(self):
+        temba_contact = TembaContact.create(uuid='C-006', name="Jan", urns=['tel:123'],
+                                            groups=['G-001', 'G-007'],
+                                            fields={'registration_date': None, 'state': None,
+                                                    'lga': None, 'occupation': None, 'born': None,
+                                                    'gender': None},
+                                            language='eng')
+
+        contact = Contact.update_or_create_from_temba(self.nigeria, temba_contact)
+
+        self.assertEqual(contact.uuid, 'C-006')
+
+        updated_contact = Contact.update_or_create_from_temba(self.nigeria, temba_contact)
+
+        self.assertEqual(contact.pk, updated_contact.pk)
 
     def test_contact_ward_field(self):
 


### PR DESCRIPTION
This will calculate the results for poll and mark it as synced once we have pulled 100k runs and keep pulling until completed.

this will display the poll to the public sooner