### PR TITLE
Fix refetch poll on big orgs

### DIFF
--- a/ureport/backend/rapidpro.py
+++ b/ureport/backend/rapidpro.py
@@ -316,7 +316,6 @@ class RapidProBackend(BaseBackend):
 
                 if pull_after_delete is not None:
                     after = None
-                    before = datetime_to_json_date(timezone.now())
                     latest_synced_obj_time = None
                     batches_latest = None
                     resume_cursor = None

--- a/ureport/backend/rapidpro.py
+++ b/ureport/backend/rapidpro.py
@@ -314,13 +314,17 @@ class RapidProBackend(BaseBackend):
                 (after, before, latest_synced_obj_time,
                  batches_latest, resume_cursor, pull_after_delete) = poll.get_pull_cached_params()
 
+                if pull_after_delete is not None:
+                    after = None
+                    before = datetime_to_json_date(timezone.now())
+                    latest_synced_obj_time = None
+                    batches_latest = None
+                    resume_cursor = None
+                    poll.delete_poll_results()
+
                 if resume_cursor is None:
                     before = datetime_to_json_date(timezone.now())
                     after = latest_synced_obj_time
-
-                if pull_after_delete is not None:
-                    after = None
-                    poll.delete_poll_results()
 
                 start = time.time()
                 print "Start fetching runs for poll #%d on org #%d" % (poll.pk, org.pk)

--- a/ureport/backend/tests/test_rapidpro.py
+++ b/ureport/backend/tests/test_rapidpro.py
@@ -1510,3 +1510,23 @@ class PerfTest(UreportTest):
         self.assertEqual(set(expected_args), set(self.get_mock_args_list(mock_cache_set)))
         mock_cache_delete.assert_called_once_with(
             Poll.POLL_RESULTS_LAST_PULL_CURSOR % (self.nigeria.pk, poll.flow_uuid))
+
+        mock_cache_delete.reset_mock()
+        mock_get_runs.reset_mock()
+        mock_get_pull_cached_params.side_effect = [('2015-04-03T12:48:44.320Z', '2015-04-04T12:48:44.320Z',
+                                                    '2015-04-05T12:48:44.320Z', None, 'cursor_string',
+                                                    '2015-04-07T12:48:44.320Z')]
+        mock_get_runs.side_effect = [MockClientQuery(*[])]
+
+        (num_val_created, num_val_updated, num_val_ignored,
+         num_path_created, num_path_updated, num_path_ignored) = self.backend.pull_results(poll, None, None)
+
+        expected_args = [(Poll.POLL_PULL_ALL_RESULTS_AFTER_DELETE_FLAG % (poll.org_id, poll.pk),),
+                         (Poll.POLL_RESULTS_CURSOR_AFTER_CACHE_KEY % (poll.org.pk, poll.flow_uuid),),
+                         (Poll.POLL_RESULTS_CURSOR_BEFORE_CACHE_KEY % (poll.org.pk, poll.flow_uuid),),
+                         (Poll.POLL_RESULTS_BATCHES_LATEST_CACHE_KEY % (poll.org.pk, poll.flow_uuid),),
+                         (Poll.POLL_RESULTS_LAST_PULL_CACHE_KEY % (poll.org.pk, poll.flow_uuid),),
+                         (Poll.POLL_RESULTS_LAST_PULL_CURSOR % (poll.org.pk, poll.flow_uuid),)]
+
+        self.assertEqual(set(expected_args), set(self.get_mock_args_list(mock_cache_delete)))
+        mock_get_runs.assert_called_once_with(flow=poll.flow_uuid, after=None, before="2015-04-08T12:48:44.320Z")

--- a/ureport/backend/tests/test_rapidpro.py
+++ b/ureport/backend/tests/test_rapidpro.py
@@ -127,6 +127,15 @@ class BoundarySyncerTest(UreportTest):
 
         self.assertFalse(self.syncer.update_required(local, remote, self.syncer.local_kwargs(self.nigeria, remote)))
 
+        local = Boundary.objects.create(org=self.nigeria, osm_id='SOME124', name='Location', parent=None,
+                                        level=Boundary.STATE_LEVEL,
+                                        geometry='{}')
+
+        remote = TembaBoundary.create(osm_id='SOME124', name='Location', parent=None, level=Boundary.COUNTRY_LEVEL,
+                                      geometry=None)
+
+        self.assertTrue(self.syncer.update_required(local, remote, self.syncer.local_kwargs(self.nigeria, remote)))
+
     def test_delete_local(self):
 
         local = Boundary.objects.create(org=self.nigeria, osm_id='OLD123', name='OLD', parent=None,

--- a/ureport/polls/models.py
+++ b/ureport/polls/models.py
@@ -198,6 +198,11 @@ class Poll(SmartModel):
         print "Deleted %d poll results for poll #%d on org #%d" % (results_ids_count, self.pk, self.org_id)
 
         cache.delete(Poll.POLL_PULL_ALL_RESULTS_AFTER_DELETE_FLAG % (self.org_id, self.pk))
+        cache.delete(Poll.POLL_RESULTS_CURSOR_AFTER_CACHE_KEY % (self.org.pk, self.flow_uuid))
+        cache.delete(Poll.POLL_RESULTS_CURSOR_BEFORE_CACHE_KEY % (self.org.pk, self.flow_uuid))
+        cache.delete(Poll.POLL_RESULTS_BATCHES_LATEST_CACHE_KEY % (self.org.pk, self.flow_uuid))
+        cache.delete(Poll.POLL_RESULTS_LAST_PULL_CACHE_KEY % (self.org.pk, self.flow_uuid))
+        cache.delete(Poll.POLL_RESULTS_LAST_PULL_CURSOR % (self.org.pk, self.flow_uuid))
 
     def update_questions_results_cache(self):
         for question in self.questions.all():


### PR DESCRIPTION
We were still using the pull cached params and on big orgs the refetch with those gives wrong stats