### PR TITLE
Update flow data should make sure poll without questions are hidden

### DIFF
--- a/ureport/settings_common.py
+++ b/ureport/settings_common.py
@@ -600,10 +600,10 @@ PREVIOUS_ORG_SITES = [
     ),
     dict(
         name="Zambia",
-        host="http://www.zambiaureport.org/home/",
+        host="https://www.zambiaureport.com/home/",
         flag="flag_zm.png",
         is_static=True,
-        count_link='http://www.zambiaureport.org/count.txt/',
+        count_link='https://www.zambiaureport.com/count.txt/',
     ),
 ]
 

--- a/ureport/utils/__init__.py
+++ b/ureport/utils/__init__.py
@@ -278,6 +278,10 @@ def update_poll_flow_data(org):
                 if runs_count > 0 and runs_count != poll.runs_count:
                     updated_fields['runs_count'] = runs_count
 
+                # make sure polls without questions are hidden to public
+                if not poll.get_questions().exists():
+                    updated_fields['is_active'] = False
+
                 if updated_fields:
                     Poll.objects.filter(pk=poll.pk).update(**updated_fields)
 

--- a/ureport/utils/tests.py
+++ b/ureport/utils/tests.py
@@ -563,7 +563,7 @@ class UtilsTest(UreportTest):
                         self.assertEqual(old_site_values,
                                          [{'time': 500, 'results': dict(size=300)}] * settings_sites_count)
 
-                        mock_get.assert_called_with('http://www.zambiaureport.org/count.txt/')
+                        mock_get.assert_called_with('https://www.zambiaureport.com/count.txt/')
 
                         cache_set_mock.assert_called_with('org:zambia:reporters:old-site',
                                                        {'time': 500, 'results': dict(size=300)},


### PR DESCRIPTION
Users on slow connections tend to create two polls at the same time
If that happens make sure the poll without questions has is_active= False automatically when we update the flow data