### PR TITLE
Makes dark section on home for all the picture

### DIFF
--- a/templates/public/index.haml
+++ b/templates/public/index.haml
@@ -44,7 +44,7 @@
   -else
     - if latest_poll
       .hero-container
-        .hero-dark-container{style:"height: auto;"}
+        .hero-dark-container
           .container
             .hero-small-background
             .row


### PR DESCRIPTION
When height:auto is working, home page hero block isn't darker complete, but only the first part. This create a different behavior from other pages on the website.

Before
![ureport_home_01](https://user-images.githubusercontent.com/507068/33087440-8817730c-cee2-11e7-9929-79598f9b0a54.png)

After
![ureport_home_02](https://user-images.githubusercontent.com/507068/33087441-8859a4fc-cee2-11e7-87a1-f8fdbcd64631.png)

