### PR TITLE
Use redis to record the last time a poll synced for long running 

### DIFF
--- a/ureport/backend/rapidpro.py
+++ b/ureport/backend/rapidpro.py
@@ -627,3 +627,11 @@ class RapidProBackend(BaseBackend):
                   datetime_to_json_date(timezone.now()), None)
         # clear the saved cursor
         cache.delete(Poll.POLL_RESULTS_LAST_PULL_CURSOR % (org.pk, poll.flow_uuid))
+
+        # Use redis with expiring(in 48 hrs) key to allow other polls task
+        # to sync all polls without hitting the API rate limit
+        r = get_redis_connection()
+        key = Poll.POLL_RESULTS_LAST_OTHER_POLLS_SYNCED_CACHE_KEY % (org.id, poll.flow_uuid)
+        r.set(key, "%s" % timezone.now().isoformat(),
+              timeout=Poll.POLL_RESULTS_LAST_OTHER_POLLS_SYNCED_CACHE_TIMEOUT)
+

--- a/ureport/backend/rapidpro.py
+++ b/ureport/backend/rapidpro.py
@@ -628,10 +628,7 @@ class RapidProBackend(BaseBackend):
         # clear the saved cursor
         cache.delete(Poll.POLL_RESULTS_LAST_PULL_CURSOR % (org.pk, poll.flow_uuid))
 
-        # Use redis with expiring(in 48 hrs) key to allow other polls task
+        # Use redis cache with expiring(in 48 hrs) key to allow other polls task
         # to sync all polls without hitting the API rate limit
-        r = get_redis_connection()
-        key = Poll.POLL_RESULTS_LAST_OTHER_POLLS_SYNCED_CACHE_KEY % (org.id, poll.flow_uuid)
-        r.set(key, "%s" % timezone.now().isoformat(),
-              timeout=Poll.POLL_RESULTS_LAST_OTHER_POLLS_SYNCED_CACHE_TIMEOUT)
-
+        cache.set(Poll.POLL_RESULTS_LAST_OTHER_POLLS_SYNCED_CACHE_KEY % (org.id, poll.flow_uuid),
+                  datetime_to_json_date(timezone.now()), Poll.POLL_RESULTS_LAST_OTHER_POLLS_SYNCED_CACHE_TIMEOUT)

--- a/ureport/backend/tests/test_rapidpro.py
+++ b/ureport/backend/tests/test_rapidpro.py
@@ -1485,7 +1485,11 @@ class PerfTest(UreportTest):
 
                          (Poll.POLL_RESULTS_LAST_SYNC_TIME_CACHE_KEY % (self.nigeria.pk, poll.flow_uuid),
                           "2015-04-08T12:48:44.320Z",
-                          None)
+                          None),
+
+                         (Poll.POLL_RESULTS_LAST_OTHER_POLLS_SYNCED_CACHE_KEY % (self.nigeria.pk, poll.flow_uuid),
+                          "2015-04-08T12:48:44.320Z",
+                          60 * 60 * 24 * 2)
                          ]
 
         self.assertEqual(set(expected_args), set(self.get_mock_args_list(mock_cache_set)))
@@ -1505,7 +1509,12 @@ class PerfTest(UreportTest):
                           None),
                          (Poll.POLL_RESULTS_LAST_SYNC_TIME_CACHE_KEY % (self.nigeria.pk, poll.flow_uuid),
                           "2015-04-08T12:48:44.320Z",
-                          None)
+                          None),
+
+                         (Poll.POLL_RESULTS_LAST_OTHER_POLLS_SYNCED_CACHE_KEY % (self.nigeria.pk, poll.flow_uuid),
+                          "2015-04-08T12:48:44.320Z",
+                          60 * 60 * 24 * 2)
+
                          ]
 
         self.assertEqual(set(expected_args), set(self.get_mock_args_list(mock_cache_set)))
@@ -1525,7 +1534,10 @@ class PerfTest(UreportTest):
                           None),
                          (Poll.POLL_RESULTS_LAST_SYNC_TIME_CACHE_KEY % (self.nigeria.pk, poll.flow_uuid),
                           "2015-04-08T12:48:44.320Z",
-                          None)
+                          None),
+                         (Poll.POLL_RESULTS_LAST_OTHER_POLLS_SYNCED_CACHE_KEY % (self.nigeria.pk, poll.flow_uuid),
+                          "2015-04-08T12:48:44.320Z",
+                          60 * 60 * 24 * 2)
                          ]
 
         self.assertEqual(set(expected_args), set(self.get_mock_args_list(mock_cache_set)))

--- a/ureport/polls/models.py
+++ b/ureport/polls/models.py
@@ -90,6 +90,10 @@ class Poll(SmartModel):
 
     POLL_RESULTS_LAST_PULL_CURSOR = 'last:poll_pull_results_cursor:org:%d:poll:%s'
 
+    POLL_RESULTS_LAST_OTHER_POLLS_SYNCED_CACHE_KEY = 'last:poll_last_other_polls_sync:org:%d:poll:%s'
+
+    POLL_RESULTS_LAST_OTHER_POLLS_SYNCED_CACHE_TIMEOUT = 60 * 60 * 24 * 2
+
     POLL_RESULTS_CURSOR_AFTER_CACHE_KEY = 'last:poll_pull_results_cursor_after:org:%d:poll:%s'
 
     POLL_RESULTS_CURSOR_BEFORE_CACHE_KEY = 'last:poll_pull_results_cursor_before:org:%d:poll:%s'

--- a/ureport/polls/tasks.py
+++ b/ureport/polls/tasks.py
@@ -83,7 +83,6 @@ def pull_results_brick_polls(org, since, until):
 @org_task('results-pull-other-polls', 60 * 60 * 24)
 def pull_results_other_polls(org, since, until):
     from .models import Poll
-    r = get_redis_connection()
 
     results_log = dict()
     other_polls_ids = Poll.get_other_polls(org).order_by('flow_uuid').distinct('flow_uuid').values_list('id', flat=True)

--- a/ureport/polls/tasks.py
+++ b/ureport/polls/tasks.py
@@ -2,6 +2,7 @@ import logging
 import time
 from dash.orgs.models import Org
 from django.core.cache import cache
+from django.utils import timezone
 from django_redis import get_redis_connection
 from ureport.celery import app
 
@@ -54,6 +55,7 @@ def pull_results_main_poll(org, since, until):
 @org_task('results-pull-brick-polls', 60 * 60 * 24)
 def pull_results_brick_polls(org, since, until):
     from .models import Poll
+    r = get_redis_connection()
 
     results_log = dict()
 
@@ -64,14 +66,17 @@ def pull_results_brick_polls(org, since, until):
 
     brick_polls = list(Poll.objects.filter(id__in=brick_polls_ids).order_by('-created_on'))[:5]
     for poll in brick_polls:
-        (num_val_created, num_val_updated, num_val_ignored,
-         num_path_created, num_path_updated, num_path_ignored) = Poll.pull_results(poll.id)
-        results_log['flow-%s' % poll.flow_uuid] = {"num_val_created": num_val_created,
-                                                   "num_val_updated": num_val_updated,
-                                                   "num_val_ignored": num_val_ignored,
-                                                   "num_path_created": num_path_created,
-                                                   "num_path_updated": num_path_updated,
-                                                   "num_path_ignored": num_path_ignored}
+
+        key = Poll.POLL_RESULTS_LAST_OTHER_POLLS_SYNCED_CACHE_KEY % (org.id, poll.flow_uuid)
+        if not r.get(key):
+            (num_val_created, num_val_updated, num_val_ignored,
+            num_path_created, num_path_updated, num_path_ignored) = Poll.pull_results(poll.id)
+            results_log['flow-%s' % poll.flow_uuid] = {"num_val_created": num_val_created,
+                                                       "num_val_updated": num_val_updated,
+                                                       "num_val_ignored": num_val_ignored,
+                                                       "num_path_created": num_path_created,
+                                                       "num_path_updated": num_path_updated,
+                                                       "num_path_ignored": num_path_ignored}
 
     return results_log
 
@@ -79,19 +84,23 @@ def pull_results_brick_polls(org, since, until):
 @org_task('results-pull-other-polls', 60 * 60 * 24)
 def pull_results_other_polls(org, since, until):
     from .models import Poll
+    r = get_redis_connection()
 
     results_log = dict()
     other_polls_ids = Poll.get_other_polls(org).order_by('flow_uuid').distinct('flow_uuid').values_list('id', flat=True)
     other_polls = Poll.objects.filter(id__in=other_polls_ids).order_by('-created_on')
     for poll in other_polls:
-        (num_val_created, num_val_updated, num_val_ignored,
-         num_path_created, num_path_updated, num_path_ignored) = Poll.pull_results(poll.id)
-        results_log['flow-%s' % poll.flow_uuid] = {"num_val_created": num_val_created,
-                                                   "num_val_updated": num_val_updated,
-                                                   "num_val_ignored": num_val_ignored,
-                                                   "num_path_created": num_path_created,
-                                                   "num_path_updated": num_path_updated,
-                                                   "num_path_ignored": num_path_ignored}
+
+        key = Poll.POLL_RESULTS_LAST_OTHER_POLLS_SYNCED_CACHE_KEY % (org.id, poll.flow_uuid)
+        if not r.get(key):
+            (num_val_created, num_val_updated, num_val_ignored,
+            num_path_created, num_path_updated, num_path_ignored) = Poll.pull_results(poll.id)
+            results_log['flow-%s' % poll.flow_uuid] = {"num_val_created": num_val_created,
+                                                        "num_val_updated": num_val_updated,
+                                                        "num_val_ignored": num_val_ignored,
+                                                        "num_path_created": num_path_created,
+                                                        "num_path_updated": num_path_updated,
+                                                        "num_path_ignored": num_path_ignored}
 
     return results_log
 

--- a/ureport/polls/tasks.py
+++ b/ureport/polls/tasks.py
@@ -55,7 +55,6 @@ def pull_results_main_poll(org, since, until):
 @org_task('results-pull-brick-polls', 60 * 60 * 24)
 def pull_results_brick_polls(org, since, until):
     from .models import Poll
-    r = get_redis_connection()
 
     results_log = dict()
 
@@ -68,7 +67,7 @@ def pull_results_brick_polls(org, since, until):
     for poll in brick_polls:
 
         key = Poll.POLL_RESULTS_LAST_OTHER_POLLS_SYNCED_CACHE_KEY % (org.id, poll.flow_uuid)
-        if not r.get(key):
+        if not cache.get(key):
             (num_val_created, num_val_updated, num_val_ignored,
             num_path_created, num_path_updated, num_path_ignored) = Poll.pull_results(poll.id)
             results_log['flow-%s' % poll.flow_uuid] = {"num_val_created": num_val_created,
@@ -92,7 +91,7 @@ def pull_results_other_polls(org, since, until):
     for poll in other_polls:
 
         key = Poll.POLL_RESULTS_LAST_OTHER_POLLS_SYNCED_CACHE_KEY % (org.id, poll.flow_uuid)
-        if not r.get(key):
+        if not cache.get(key):
             (num_val_created, num_val_updated, num_val_ignored,
             num_path_created, num_path_updated, num_path_ignored) = Poll.pull_results(poll.id)
             results_log['flow-%s' % poll.flow_uuid] = {"num_val_created": num_val_created,

--- a/ureport/polls/tests.py
+++ b/ureport/polls/tests.py
@@ -1922,30 +1922,17 @@ class PollsTasksTest(UreportTest):
 
         mock_pull_results.assert_called_once()
 
+    @patch('django.core.cache.cache.get')
     @patch('ureport.tests.TestBackend.pull_results')
     @patch('ureport.polls.models.Poll.get_other_polls')
-    def test_pull_results_other_polls(self, mock_get_other_polls, mock_pull_results):
+    def test_pull_results_other_polls(self, mock_get_other_polls, mock_pull_results, mock_cache_get):
         mock_get_other_polls.return_value = self.polls_query
         mock_pull_results.return_value = (1, 2, 3, 4, 5, 6)
+        mock_cache_get.return_value = None
 
         pull_results_other_polls(self.nigeria.pk)
 
         task_state = TaskState.objects.get(org=self.nigeria, task_key='results-pull-other-polls')
-        self.assertEqual(task_state.get_last_results()['flow-%s' % self.poll.flow_uuid],
-                         {"num_val_created": 1, "num_val_updated": 2, "num_val_ignored": 3,
-                          "num_path_created": 4, "num_path_updated": 5, "num_path_ignored": 6})
-
-        mock_pull_results.assert_called_once()
-
-    @patch('ureport.tests.TestBackend.pull_results')
-    @patch('ureport.polls.models.Poll.get_recent_polls')
-    def test_pull_results_other_polls(self, mock_get_recent_polls, mock_pull_results):
-        mock_get_recent_polls.return_value = self.polls_query
-        mock_pull_results.return_value = (1, 2, 3, 4, 5, 6)
-
-        pull_results_recent_polls(self.nigeria.pk)
-
-        task_state = TaskState.objects.get(org=self.nigeria, task_key='results-pull-recent-polls')
         self.assertEqual(task_state.get_last_results()['flow-%s' % self.poll.flow_uuid],
                          {"num_val_created": 1, "num_val_updated": 2, "num_val_ignored": 3,
                           "num_path_created": 4, "num_path_updated": 5, "num_path_ignored": 6})

--- a/ureport/settings_common.py
+++ b/ureport/settings_common.py
@@ -503,13 +503,13 @@ CELERYBEAT_SCHEDULE = {
     },
     'results-pull-brick-polls':  {
         'task': 'dash.orgs.tasks.trigger_org_task',
-        "schedule": timedelta(hours=48),
+        "schedule": timedelta(hours=1),
         "relative": True,
         'args': ('ureport.polls.tasks.pull_results_brick_polls', 'sync')
     },
     'results-pull-other-polls':  {
         'task': 'dash.orgs.tasks.trigger_org_task',
-        "schedule": timedelta(hours=48),
+        "schedule": timedelta(hours=1),
         "relative": True,
         'args': ('ureport.polls.tasks.pull_results_other_polls', 'sync')
     },


### PR DESCRIPTION
Alternative approach for long running tasks like other_polls_task to skip poll that have a value set in redis that expires in 48 hours

