### PR TITLE
Add limit poll states config for superusers

### DIFF
--- a/ureport/locations/models.py
+++ b/ureport/locations/models.py
@@ -98,7 +98,13 @@ class Boundary(models.Model):
         if org.get_config("common.is_global"):
             top_boundaries = cls.objects.filter(org=org, level=cls.COUNTRY_LEVEL)
         else:
-            top_boundaries = cls.objects.filter(org=org, level=cls.STATE_LEVEL)
+            # just listing states that are limited
+            limit_states = org.get_config("common.limit_poll_states")
+            if limit_states:
+                limit_states = [elt.strip() for elt in limit_states.split(",")]
+                top_boundaries = cls.objects.filter(org=org, level=cls.STATE_LEVEL, name__in=limit_states)
+            else:
+                top_boundaries = cls.objects.filter(org=org, level=cls.STATE_LEVEL)
 
         top_boundaries_values = top_boundaries.values("name", "osm_id")
 

--- a/ureport/public/tests.py
+++ b/ureport/public/tests.py
@@ -54,7 +54,7 @@ class PublicTest(UreportTest):
         self.login(self.superuser)
         response = self.client.get(edit_url, SERVER_NAME="nigeria.ureport.io")
         self.assertTrue("form" in response.context)
-        self.assertEqual(len(response.context["form"].fields), 60)
+        self.assertEqual(len(response.context["form"].fields), 61)
 
     def test_count(self):
         count_url = reverse("public.count")

--- a/ureport/public_v2/tests.py
+++ b/ureport/public_v2/tests.py
@@ -48,7 +48,7 @@ class PublicTest(UreportTest):
         self.login(self.superuser)
         response = self.client.get(edit_url, SERVER_NAME="nigeria.ureport.io")
         self.assertTrue("form" in response.context)
-        self.assertEqual(len(response.context["form"].fields), 60)
+        self.assertEqual(len(response.context["form"].fields), 61)
 
     def test_count(self):
         count_url = reverse("v2.public.count")

--- a/ureport/settings_common.py
+++ b/ureport/settings_common.py
@@ -392,6 +392,11 @@ ORG_CONFIG_FIELDS = [
         superuser_only=True,
     ),
     dict(
+        name="limit_poll_states",
+        field=dict(help_text=_("The states to show on maps only, used to filter poll results"), required=False),
+        superuser_only=True,
+    ),
+    dict(
         name="google_tracking_id",
         field=dict(
             help_text=_("The Google Analytics Tracking ID for this organization"),


### PR DESCRIPTION
We've faced a very specific use case in Serbia, where some states need to appear on the map, but they couldn't appear in the poll results (for political reasons). This PR keeps the limit states config to remove states in the engagement map but creates a new config for limiting states in poll results.