### PR TITLE
Eenable locale for Serbian Latin Serbia language

### DIFF
--- a/ureport/settings_common.py
+++ b/ureport/settings_common.py
@@ -82,7 +82,6 @@ LANGUAGES = (
     ("it", "Italian"),
     ("ro", "Romanian"),
     ("vi", "Vietnamese"),
-    ("sr-latn", "Latin Serbian"),
     ("sr-rs@latin", "Serbian (Latin, Serbia)"),
 )
 

--- a/ureport/settings_common.py
+++ b/ureport/settings_common.py
@@ -83,6 +83,7 @@ LANGUAGES = (
     ("ro", "Romanian"),
     ("vi", "Vietnamese"),
     ("sr-latn", "Latin Serbian"),
+    ("sr-rs@latin", "Serbian (Latin, Serbia)"),
 )
 
 DEFAULT_LANGUAGE = "en"


### PR DESCRIPTION
Hi everyone, I open this PR to have available the Serbian Latin Language (`sr_RS@latin`) on the UReport. This locale on transifex has 100% translated.