### PR TITLE
Fixing on image responsivity while scaling large images on story detail

### DIFF
--- a/templates/public/story_read.haml
+++ b/templates/public/story_read.haml
@@ -156,7 +156,9 @@
     }
 
     .story-details img {
-      max-width: 100%;
+      height: auto !important;
+      display: block;
+      width: 100% !important;
     }
 
 -block extra-script


### PR DESCRIPTION
Large images on small devices becomes stretched, this small fix solves this problem keeping image aspect ratio inside 'story detail' on v1.