### PR TITLE
Adjustments on chunk_list(iterable, size), to avoid a runtime error

### DIFF
--- a/ureport/utils/__init__.py
+++ b/ureport/utils/__init__.py
@@ -116,7 +116,10 @@ def chunk_list(iterable, size):
     source_iter = iter(iterable)
     while True:
         chunk_iter = islice(source_iter, size)
-        yield chain([next(chunk_iter)], chunk_iter)
+        try:
+            yield chain([next(chunk_iter)], chunk_iter)
+        except StopIteration:
+            return
 
 
 def get_linked_orgs(authenticated=False):


### PR DESCRIPTION
"RuntimeError: generator raised StopIteration"

This error occurs when chunk_list is invoked. This fixing makes this functions behaves according to the python 3.7 behaviour (PEP 479).
![Captura de Tela 2019-12-03 às 11 47 30](https://user-images.githubusercontent.com/18359717/70061282-c3bcf200-15c2-11ea-8bdd-262a80f5a304.png)
