### PR TITLE
[FIX]: temba_client version to v2 on migration files

### DIFF
--- a/ureport/polls/migrations/0023_populate_flow_date.py
+++ b/ureport/polls/migrations/0023_populate_flow_date.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 
-from temba_client.v1 import TembaClient
+from temba_client.v2 import TembaClient
 
 from django.conf import settings
 from django.db import migrations

--- a/ureport/polls/migrations/0029_populate_response_categories.py
+++ b/ureport/polls/migrations/0029_populate_response_categories.py
@@ -6,7 +6,7 @@ import time
 
 import six
 from temba_client.exceptions import TembaBadRequestError
-from temba_client.v1 import TembaClient
+from temba_client.v2 import TembaClient
 
 from django.conf import settings
 from django.db import migrations


### PR DESCRIPTION
- The temba_client version was outdated, and the `python manage.py migrate` command was failing because the correct version is temba_client.v2.