### PR TITLE
Fix stories list in index page

### DIFF
--- a/templates/public_base.haml
+++ b/templates/public_base.haml
@@ -530,11 +530,11 @@
      
       -block content
   
-      {% if main_stories|slice:"1:" %}
+      {% if main_stories|slice:"0:" %}
       // footer stories
       .bg-dark-blue
         .max-w-page.mx-auto.text-white.px-home.pt-home.hover-parent(class="md:flex")
-          - for story in main_stories|slice:"1:4"
+          - for story in main_stories|slice:"0:3"
             %a.block.mt-6.p-4(class="md:mt-4 {% if not forloop.first %} md:ml-4 {% endif %} md:w-1/3 md:p-0" href="{% url 'public.story_read' story.pk %}")
               .block
                 {% thumbnail story.get_image "400x250" crop="top" as im %}


### PR DESCRIPTION
When creating a new story in `manage/story/` it should appear on the home page, as the first item on the list, however, this does not happen. On the home page, stories are being listed incorrectly, starting from the second item.

- The problem is:
![Captura de Tela_Área de Seleção_20201209092526](https://user-images.githubusercontent.com/49874732/101643580-081f7100-3a13-11eb-9a9a-dc3e17270ca7.png)
![Captura de Tela_Área de Seleção_20201209093227](https://user-images.githubusercontent.com/49874732/101643445-ea520c00-3a12-11eb-946a-cd77743c7440.png)

To solve this problem I changed the filter responsible for listing them.

- in `templates/public_base.haml` line `537`
```
-        - for story in main_stories|slice:"1:4"
+        - for story in main_stories|slice:"0:3"
```