### PR TITLE
Pull results from archives for really old flow polls

### DIFF
--- a/pip-freeze.txt
+++ b/pip-freeze.txt
@@ -21,7 +21,7 @@ django-rest-swagger==2.2.0
 django-rosetta==0.8.3
 django-storages==1.11.1; python_version >= "3.5"
 django-timezone-field==4.1.2; python_version >= "3.6" and python_version < "4.0"
-django==2.2.19; python_version >= "3.5"
+django==2.2.20; python_version >= "3.5"
 djangorestframework==3.8.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 feedparser==6.0.2; python_version >= "3.6"
 gitdb2==2.0.6; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -209,7 +209,7 @@ python-versions = "*"
 
 [[package]]
 name = "django"
-version = "2.2.19"
+version = "2.2.20"
 description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
 category = "main"
 optional = false
@@ -1006,7 +1006,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "b5dcdf5d68714bb83e5778466586ab9e0cc513822be392951991a83b11644f6f"
+content-hash = "1d40eed46ac15071d9f35640dc54a9237e4b7531583f4cc08a8c9435be75bd3b"
 
 [metadata.files]
 amqp = [
@@ -1103,8 +1103,8 @@ dj-database-url = [
     {file = "dj_database_url-0.5.0-py2.py3-none-any.whl", hash = "sha256:851785365761ebe4994a921b433062309eb882fedd318e1b0fcecc607ed02da9"},
 ]
 django = [
-    {file = "Django-2.2.19-py3-none-any.whl", hash = "sha256:e319a7164d6d30cb177b3fd74d02c52f1185c37304057bb76d74047889c605d9"},
-    {file = "Django-2.2.19.tar.gz", hash = "sha256:30c235dec87e05667597e339f194c9fed6c855bda637266ceee891bf9093da43"},
+    {file = "Django-2.2.20-py3-none-any.whl", hash = "sha256:2484f115891ab1a0e9ae153602a641fbc15d7894c036d79fb78662c0965d7954"},
+    {file = "Django-2.2.20.tar.gz", hash = "sha256:2569f9dc5f8e458a5e988b03d6b7a02bda59b006d6782f4ea0fd590ed7336a64"},
 ]
 django-appconf = [
     {file = "django-appconf-1.0.4.tar.gz", hash = "sha256:be58deb54a43d77d2e1621fe59f787681376d3cd0b8bd8e4758ef6c3a6453380"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-Django = "~2.2.13"
+Django = "~2.2.20"
 smartmin = "~2.3.2"
 rapidpro-dash = "~1.6.0"
 colorama = "^0.4.3"

--- a/test-freeze.txt
+++ b/test-freeze.txt
@@ -25,7 +25,7 @@ django-rest-swagger==2.2.0
 django-rosetta==0.8.3
 django-storages==1.11.1; python_version >= "3.5"
 django-timezone-field==4.1.2; python_version >= "3.6" and python_version < "4.0"
-django==2.2.19; python_version >= "3.5"
+django==2.2.20; python_version >= "3.5"
 djangorestframework==3.8.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 feedparser==6.0.2; python_version >= "3.6"
 flake8==3.9.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")

--- a/ureport/backend/rapidpro.py
+++ b/ureport/backend/rapidpro.py
@@ -449,7 +449,8 @@ class RapidProBackend(BaseBackend):
             )
 
         with r.lock(key):
-            first = poll.poll_date.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+            flow_date = poll.get_flow_date()
+            first = flow_date.replace(day=1, hour=0, minute=0, second=0, microsecond=0) if flow_date else None
 
             client = self._get_client(org, 2)
 

--- a/ureport/polls/tasks.py
+++ b/ureport/polls/tasks.py
@@ -204,9 +204,15 @@ def clear_old_poll_results(org, since, until):
 
     now = timezone.now()
     r = get_redis_connection()
-    time_window = now - timedelta(days=90)
+    syncing_window = now - timedelta(days=90)
+    new_window = now - timedelta(days=14)
 
-    old_polls = Poll.objects.filter(org=org).exclude(poll_date__gte=time_window).order_by("pk")
+    old_polls = (
+        Poll.objects.filter(org=org)
+        .exclude(poll_date__gte=syncing_window)
+        .exclude(created_on__gte=new_window)
+        .order_by("pk")
+    )
     for poll in old_polls:
 
         key = Poll.POLL_PULL_RESULTS_TASK_LOCK % (org.pk, poll.flow_uuid)

--- a/ureport/polls/tests.py
+++ b/ureport/polls/tests.py
@@ -1570,11 +1570,16 @@ class PollTest(UreportTest):
 
         self.assertFalse(PollResult.objects.filter(org=self.nigeria, flow=poll.flow_uuid))
 
+    @patch("ureport.polls.tasks.pull_refresh_from_archives.apply_async")
+    @patch("ureport.polls.models.Poll.get_flow_date")
     @patch("dash.orgs.models.Org.get_backend")
     @patch("ureport.tests.TestBackend.pull_results")
-    def test_poll_pull_results(self, mock_pull_results, mock_get_backend):
+    def test_poll_pull_results(
+        self, mock_pull_results, mock_get_backend, mock_poll_flow_date, mock_pull_refresh_from_archives_task
+    ):
         mock_get_backend.return_value = TestBackend(self.rapidpro_backend)
         mock_pull_results.return_value = (1, 2, 3, 4, 5, 6)
+        mock_poll_flow_date.return_value = None
 
         poll = self.create_poll(self.nigeria, "Poll 1", "flow-uuid", self.education_nigeria, self.admin)
 
@@ -1583,6 +1588,8 @@ class PollTest(UreportTest):
 
         poll = Poll.objects.get(pk=poll.pk)
         self.assertTrue(poll.has_synced)
+
+        mock_pull_refresh_from_archives_task.assert_called_once_with((poll.pk,), queue="sync")
 
         self.assertEqual(mock_get_backend.call_args[1], {"backend_slug": "rapidpro"})
         mock_pull_results.assert_called_once()
@@ -2851,13 +2858,15 @@ class PollsTasksTest(UreportTest):
         self.create_poll(self.nigeria, "Poll 4", "", self.education_nigeria, self.admin, has_synced=False)
         self.create_poll(self.nigeria, "Poll 5", "", self.education_nigeria, self.admin, has_synced=True)
 
+    @patch("ureport.polls.models.Poll.get_flow_date")
     @patch("dash.orgs.models.Org.get_backend")
     @patch("ureport.tests.TestBackend.pull_results")
     @patch("ureport.polls.models.Poll.get_main_poll")
-    def test_pull_results_main_poll(self, mock_get_main_poll, mock_pull_results, mock_get_backend):
+    def test_pull_results_main_poll(self, mock_get_main_poll, mock_pull_results, mock_get_backend, mock_get_flow_date):
         mock_get_backend.return_value = TestBackend(self.rapidpro_backend)
         mock_get_main_poll.return_value = self.poll
         mock_pull_results.return_value = (1, 2, 3, 4, 5, 6)
+        mock_get_flow_date.return_value = None
 
         pull_results_main_poll(self.nigeria.pk)
 
@@ -2874,13 +2883,17 @@ class PollsTasksTest(UreportTest):
             },
         )
 
+    @patch("ureport.polls.models.Poll.get_flow_date")
     @patch("dash.orgs.models.Org.get_backend")
     @patch("ureport.tests.TestBackend.pull_results")
     @patch("ureport.polls.models.Poll.get_brick_polls_ids")
-    def test_pull_results_brick_polls(self, mock_get_brick_polls_ids, mock_pull_results, mock_get_backend):
+    def test_pull_results_brick_polls(
+        self, mock_get_brick_polls_ids, mock_pull_results, mock_get_backend, mock_get_flow_date
+    ):
         mock_get_backend.return_value = TestBackend(self.rapidpro_backend)
         mock_get_brick_polls_ids.return_value = [poll.pk for poll in self.polls_query]
         mock_pull_results.return_value = (1, 2, 3, 4, 5, 6)
+        mock_get_flow_date.return_value = None
 
         pull_results_brick_polls(self.nigeria.pk)
 
@@ -2908,15 +2921,19 @@ class PollsTasksTest(UreportTest):
         self.assertEqual(task_state.get_last_results(), {})
         mock_pull_results.assert_called_once()
 
+    @patch("ureport.polls.models.Poll.get_flow_date")
     @patch("dash.orgs.models.Org.get_backend")
     @patch("django.core.cache.cache.get")
     @patch("ureport.tests.TestBackend.pull_results")
     @patch("ureport.polls.models.Poll.get_other_polls")
-    def test_pull_results_other_polls(self, mock_get_other_polls, mock_pull_results, mock_cache_get, mock_get_backend):
+    def test_pull_results_other_polls(
+        self, mock_get_other_polls, mock_pull_results, mock_cache_get, mock_get_backend, mock_get_flow_date
+    ):
         mock_get_backend.return_value = TestBackend(self.rapidpro_backend)
         mock_get_other_polls.return_value = self.polls_query
         mock_pull_results.return_value = (1, 2, 3, 4, 5, 6)
         mock_cache_get.return_value = None
+        mock_get_flow_date.return_value = None
 
         self.poll.created_on = timezone.now() - timedelta(days=8)
         self.poll.save()
@@ -2947,11 +2964,13 @@ class PollsTasksTest(UreportTest):
         self.assertEqual(task_state.get_last_results(), {})
         mock_pull_results.assert_called_once()
 
+    @patch("ureport.polls.models.Poll.get_flow_date")
     @patch("dash.orgs.models.Org.get_backend")
     @patch("ureport.tests.TestBackend.pull_results")
-    def test_backfill_poll_results(self, mock_pull_results, mock_get_backend):
+    def test_backfill_poll_results(self, mock_pull_results, mock_get_backend, mock_get_flow_date):
         mock_get_backend.return_value = TestBackend(self.rapidpro_backend)
         mock_pull_results.return_value = (1, 2, 3, 4, 5, 6)
+        mock_get_flow_date.return_value = None
 
         self.poll.has_synced = True
         self.poll.save()


### PR DESCRIPTION
Add support to automatically pull results for flows older than 90 days from the archives on the first sync