### PR TITLE
Force gc.collect after each sync fetch page

### DIFF
--- a/ureport/backend/floip.py
+++ b/ureport/backend/floip.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import gc
 import logging
 import time
 from collections import defaultdict
@@ -373,6 +374,11 @@ class FLOIPBackend(BaseBackend):
                         "runs for poll #%d on org #%d"
                         % (stats_dict["num_synced"] - len(results), stats_dict["num_synced"], poll.pk, org.pk)
                     )
+
+                    # release per-page lookup maps holding cyclic references before next allocation
+                    del contacts_map, poll_results_map, poll_results_to_save_map
+                    gc.collect()
+
                     # fetch_start = time.time()
                     logger.info("=" * 40)
 

--- a/ureport/backend/rapidpro.py
+++ b/ureport/backend/rapidpro.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import gc
 import gzip
 import io
 import json
@@ -538,6 +539,8 @@ class RapidProBackend(BaseBackend):
 
                         traceback.print_exc()
 
+                    gc.collect()
+
         return (
             stats_dict["num_val_created"],
             stats_dict["num_val_updated"],
@@ -654,6 +657,11 @@ class RapidProBackend(BaseBackend):
                             "runs for poll #%d on org #%d"
                             % (stats_dict["num_synced"] - len(fetch), stats_dict["num_synced"], poll.pk, org.pk)
                         )
+
+                        # release per-page lookup maps holding cyclic references before next allocation
+                        del contacts_map, poll_results_map, poll_results_to_save_map
+                        gc.collect()
+
                         fetch_start = time.time()
                         logger.info("=" * 40)
 

--- a/ureport/backend/rapidpro.py
+++ b/ureport/backend/rapidpro.py
@@ -532,6 +532,10 @@ class RapidProBackend(BaseBackend):
                                 % (i, time.time() - fetch_start, len(fetch))
                             )
 
+                            # release per-page lookup maps holding cyclic references before next allocation
+                            del contacts_map, poll_results_map, poll_results_to_save_map
+                            gc.collect()
+
                         logger.info("Full poll process archive in %ds" % (time.time() - start_archive))
                     except Exception as e:
                         logger.info(e)


### PR DESCRIPTION
## Summary
- Backend sync workers allocate three per-page lookup dicts (`contacts_map`, `poll_results_map`, `poll_results_to_save_map`) full of ORM model instances. The cycles between models, managers and defaultdict values keep them off the refcount fast path, so memory only drops when the gen-2 collector runs — and gen-2 has been firing less aggressively in our long-running workers.
- Drop the references and run `gc.collect()` at the end of each fetch iteration in both the RapidPro and FLOIP backends, plus at the end of each archive in the RapidPro archive-pull path.

## Test plan
- [ ] Run the existing backend test suites (`pull_results` / `pull_results_from_archives`) to confirm behaviour is unchanged.
- [ ] After deploy, watch the sync worker RSS over a few sync cycles — should plateau lower and recycle less often under the new supervisor `--max-memory-per-child` ceiling.