### PR TITLE
Fix FLOIP sync quadratic num_synced growth

### DIFF
--- a/ureport/backend/floip.py
+++ b/ureport/backend/floip.py
@@ -363,9 +363,9 @@ class FLOIPBackend(BaseBackend):
                             stats_dict,
                         )
 
-                        stats_dict["num_synced"] += len(results)
-                        if progress_callback:
-                            progress_callback(stats_dict["num_synced"])
+                    stats_dict["num_synced"] += len(results)
+                    if progress_callback:
+                        progress_callback(stats_dict["num_synced"])
 
                     self._save_new_poll_results_to_database(poll_results_to_save_map)
 

--- a/ureport/backend/tests/test_floip.py
+++ b/ureport/backend/tests/test_floip.py
@@ -1138,6 +1138,8 @@ class FLOIPBackendTest(UreportTest):
         self.create_poll_question(self.admin, poll, "question 2", "q_1522956746998_26")
         self.create_poll_question(self.admin, poll, "question 3", "q_1522957067432_34")
 
+        progress_calls = []
+
         with self.assertNumQueries(4):
             (
                 num_val_created,
@@ -1146,12 +1148,17 @@ class FLOIPBackendTest(UreportTest):
                 num_path_created,
                 num_path_updated,
                 num_path_ignored,
-            ) = self.backend.pull_results(poll, None, None)
+            ) = self.backend.pull_results(poll, None, None, progress_callback=progress_calls.append)
 
         self.assertEqual(
             (num_val_created, num_val_updated, num_val_ignored, num_path_created, num_path_updated, num_path_ignored),
             (15, 0, 8, 0, 0, 0),
         )
+
+        # progress_callback should be called once per page with the cumulative number of synced runs.
+        # The mocked response has 23 entries on a single page, so num_synced must be 23 — not 23*23 (the
+        # value seen when the per-page increment was incorrectly nested inside the per-result loop).
+        self.assertEqual(progress_calls, [23])
         mock_valkey_lock.assert_called_once_with(
             Poll.POLL_PULL_RESULTS_TASK_LOCK % (poll.org.pk, poll.flow_uuid), timeout=7200
         )


### PR DESCRIPTION
## Summary

- In `FLOIPBackend.pull_results`, `stats_dict["num_synced"] += len(results)` and the `progress_callback` invocation were nested inside the per-result loop. Per page, the counter grew by `len(results) ** 2` instead of `len(results)`.
- This inflated the logged "Processed fetch of X - Y" range, made `progress_callback` report wildly wrong totals, and tripped the `POLL_RESULTS_MAX_SYNC_RUNS` pause far too early — prematurely halting sync.
- Moves both the increment and the callback out one level so they fire exactly once per page, matching the RapidPro backend's `pull_results`.

Flagged as a side observation on #1354 (gc.collect changes) and split out into its own change.

## Test plan

- [x] Extended `FLOIPBackendTest.test_pull_results` to pass a `progress_callback` and assert it is called once per page with the page size — i.e. `[23]`, not `[23, 46, ..., 529]`.
- [x] `manage.py test ureport.backend.tests.test_floip` — all 7 tests pass.