### PR TITLE
Require Python 3.14.5+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {"name" = "Nyaruka", "email" = "code@nyaruka.com"}
 ]
 readme = "README.md"
-requires-python = ">=3.14,<3.15"
+requires-python = ">=3.14.5,<3.15"
 dependencies = [
     "django>=6.0.5,<6.1",
     "smartmin>=6.0.0,<6.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = "==3.14.*"
+requires-python = ">=3.14.5, <3.15"
 
 [[package]]
 name = "amqp"


### PR DESCRIPTION
## Summary
- Bump `requires-python` from `>=3.14,<3.15` to `>=3.14.5,<3.15` to pick up the GC fix in CPython 3.14.5.
- Lock file regenerated.

No infra changes required: `uv venv` / `uv sync` will auto-download a managed python-build-standalone 3.14.5 interpreter on next deploy if the system Python doesn't satisfy the new constraint.

## Test plan
- [ ] CI passes
- [ ] Next deploy: confirm `uv sync` either reuses an existing 3.14.5 or pulls a managed one without manual intervention