### PR TITLE
Add org object permission check to poll pull refresh view

### DIFF
--- a/ureport/polls/tests.py
+++ b/ureport/polls/tests.py
@@ -94,13 +94,37 @@ class PollTest(UreportTest):
             response = self.client.post(pull_refresh_url, post_data, SERVER_NAME="uganda.ureport.io")
             self.assertLoginRedirect(response)
 
-            self.login(self.admin)
+            # an admin of a different org cannot pull refresh this poll, from their own site
+            other_org_admin = self.create_user("OtherOrgAdmin")
+            self.nigeria.administrators.add(other_org_admin)
+            self.login(other_org_admin)
 
-            response = self.client.get(pull_refresh_url, SERVER_NAME="uganda.ureport.io")
+            response = self.client.post(pull_refresh_url, post_data, SERVER_NAME="nigeria.ureport.io")
             self.assertLoginRedirect(response)
+            mock_pull_refresh.assert_not_called()
 
+            # nor from the poll org's site, where they are not a member
             response = self.client.post(pull_refresh_url, post_data, SERVER_NAME="uganda.ureport.io")
             self.assertLoginRedirect(response)
+            mock_pull_refresh.assert_not_called()
+
+            # an admin of the poll's own org can pull refresh it
+            self.login(self.admin)
+
+            response = self.client.post(pull_refresh_url, post_data, SERVER_NAME="uganda.ureport.io")
+            self.assertEqual(response.status_code, 302)
+            mock_pull_refresh.assert_called_once_with()
+            mock_pull_refresh.reset_mock()
+
+            # so can an editor of the poll's own org
+            org_editor = self.create_user("OrgEditor")
+            self.uganda.editors.add(org_editor)
+            self.login(org_editor)
+
+            response = self.client.post(pull_refresh_url, post_data, SERVER_NAME="uganda.ureport.io")
+            self.assertEqual(response.status_code, 302)
+            mock_pull_refresh.assert_called_once_with()
+            mock_pull_refresh.reset_mock()
 
             self.login(self.superuser)
 

--- a/ureport/polls/tests.py
+++ b/ureport/polls/tests.py
@@ -94,32 +94,27 @@ class PollTest(UreportTest):
             response = self.client.post(pull_refresh_url, post_data, SERVER_NAME="uganda.ureport.io")
             self.assertLoginRedirect(response)
 
-            # an admin of a different org cannot pull refresh this poll, from their own site
-            other_org_admin = self.create_user("OtherOrgAdmin")
-            self.nigeria.administrators.add(other_org_admin)
-            self.login(other_org_admin)
-
-            response = self.client.post(pull_refresh_url, post_data, SERVER_NAME="nigeria.ureport.io")
-            self.assertLoginRedirect(response)
-            mock_pull_refresh.assert_not_called()
-
-            # nor from the poll org's site, where they are not a member
-            response = self.client.post(pull_refresh_url, post_data, SERVER_NAME="uganda.ureport.io")
-            self.assertLoginRedirect(response)
-            mock_pull_refresh.assert_not_called()
-
-            # an admin of the poll's own org can pull refresh it
+            # org admins cannot pull refresh polls, not even for their own org
             self.login(self.admin)
 
             response = self.client.post(pull_refresh_url, post_data, SERVER_NAME="uganda.ureport.io")
-            self.assertEqual(response.status_code, 302)
-            mock_pull_refresh.assert_called_once_with()
-            mock_pull_refresh.reset_mock()
+            self.assertLoginRedirect(response)
+            mock_pull_refresh.assert_not_called()
 
-            # so can an editor of the poll's own org
+            # neither can org editors
             org_editor = self.create_user("OrgEditor")
             self.uganda.editors.add(org_editor)
             self.login(org_editor)
+
+            response = self.client.post(pull_refresh_url, post_data, SERVER_NAME="uganda.ureport.io")
+            self.assertLoginRedirect(response)
+            mock_pull_refresh.assert_not_called()
+
+            # staff users can pull refresh
+            staff_user = self.create_user("Staffuser")
+            staff_user.is_staff = True
+            staff_user.save()
+            self.login(staff_user)
 
             response = self.client.post(pull_refresh_url, post_data, SERVER_NAME="uganda.ureport.io")
             self.assertEqual(response.status_code, 302)

--- a/ureport/polls/views.py
+++ b/ureport/polls/views.py
@@ -771,7 +771,7 @@ class PollCRUDL(SmartCRUDL):
             Poll.find_main_poll(org)
             return obj
 
-    class PullRefresh(SmartUpdateView):
+    class PullRefresh(ActivePollMixin, SmartUpdateView):
         fields = ()
         success_url = "@polls.poll_list"
         success_message = None

--- a/ureport/polls/views.py
+++ b/ureport/polls/views.py
@@ -776,6 +776,14 @@ class PollCRUDL(SmartCRUDL):
         success_url = "@polls.poll_list"
         success_message = None
 
+        def has_permission(self, request, *args, **kwargs):
+            self.kwargs = kwargs
+            self.args = args
+            self.request = request
+            self.org = self.derive_org()
+
+            return request.user.is_superuser or request.user.is_staff
+
         def post_save(self, obj):
             poll = self.get_object()
             poll.pull_refresh_task()


### PR DESCRIPTION
PullRefresh was the only poll CRUDL action without an org object permission check and had an unfiltered queryset, so any authenticated user holding the `polls.poll_pull_refresh` permission could trigger a pull refresh on another org's poll by pk.

Since pull refresh deletes and re-pulls all results for a poll, it is now restricted to superusers and staff users only — org administrators and editors cannot trigger it.

Tests cover: unauthenticated denial, org admin and editor denial, staff and superuser success.