### PR TITLE
Add timeouts to task locks so a killed worker cannot wedge syncing

### DIFF
--- a/ureport/backend/rapidpro.py
+++ b/ureport/backend/rapidpro.py
@@ -475,7 +475,7 @@ class RapidProBackend(BaseBackend):
                 stats_dict["num_path_ignored"],
             )
 
-        with r.lock(key):
+        with r.lock(key, timeout=Poll.POLL_PULL_ARCHIVES_LOCK_TIMEOUT):
             flow_date_json = poll.get_flow_date()
             first = (
                 json_date_to_datetime(flow_date_json).replace(day=1, hour=0, minute=0, second=0, microsecond=0)

--- a/ureport/backend/tests/test_rapidpro.py
+++ b/ureport/backend/tests/test_rapidpro.py
@@ -1931,7 +1931,10 @@ class RapidProBackendTest(UreportTest):
         )
 
         mock_get_archives.assert_called_with(type="run", after=None)
-        mock_valkey_lock.assert_called_once_with(Poll.POLL_PULL_RESULTS_TASK_LOCK % (poll.org.pk, poll.flow_uuid))
+        mock_valkey_lock.assert_called_once_with(
+            Poll.POLL_PULL_RESULTS_TASK_LOCK % (poll.org.pk, poll.flow_uuid),
+            timeout=Poll.POLL_PULL_ARCHIVES_LOCK_TIMEOUT,
+        )
 
         poll_result = PollResult.objects.filter(flow="flow-uuid", ruleset="ruleset-uuid", contact="C-001").first()
         self.assertEqual(poll_result.state, "R-LAGOS")

--- a/ureport/contacts/models.py
+++ b/ureport/contacts/models.py
@@ -243,7 +243,7 @@ class ReportersCounter(models.Model):
         if r.get(key):
             logger.info("Squash reporters counts already running.")
         else:
-            with r.lock(key):
+            with r.lock(key, timeout=60 * 60):
                 last_squash = r.get(ReportersCounter.LAST_SQUASHED_ID_KEY)
                 if not last_squash:
                     last_squash = 0

--- a/ureport/contacts/tasks.py
+++ b/ureport/contacts/tasks.py
@@ -25,7 +25,7 @@ def rebuild_contacts_counts():
     orgs = Org.objects.filter(is_active=True)
     for org in orgs:
         key = TaskState.get_lock_key(org, "contact-pull")
-        with r.lock(key):
+        with r.lock(key, timeout=60 * 60 * 12):
             Contact.recalculate_reporters_stats(org)
 
 
@@ -183,7 +183,7 @@ def populate_contact_schemes(org, since, until):
         # for ourself to make sure our task below will be run
         r.delete(contact_pull_key)
 
-    with r.lock(contact_pull_key):
+    with r.lock(contact_pull_key, timeout=60 * 60 * 24):
         last_fetch_date_key = Contact.CONTACT_LAST_FETCHED_CACHE_KEY % (org.id, "rapidpro")
         cache.delete(last_fetch_date_key)
 
@@ -256,7 +256,7 @@ def populate_contact_schemes(org, since, until):
     logger.info(f"Finished populating schemes on contacts for org #{org.id} in {elapsed:.1f} seconds")
 
     contact_count_cache_updates_key = TaskState.get_lock_key(org, "update-org-contact-counts")
-    with r.lock(contact_count_cache_updates_key):
+    with r.lock(contact_count_cache_updates_key, timeout=60 * 20):
         update_cache_org_contact_counts(org)
 
     elapsed = time.time() - start_time

--- a/ureport/polls/models.py
+++ b/ureport/polls/models.py
@@ -101,6 +101,9 @@ class Poll(SmartModel):
 
     POLL_SYNC_LOCK_TIMEOUT = 60 * 60 * 2
 
+    # archive pulls have no pause/resume checkpoint so their lock lease must cover a full worst-case run
+    POLL_PULL_ARCHIVES_LOCK_TIMEOUT = 60 * 60 * 12
+
     published = models.BooleanField(
         default=True, help_text=_("Whether this poll should be visible/hidden on the public site")
     )


### PR DESCRIPTION
Five lock acquisitions used `r.lock()` with no timeout, so a worker killed mid-task (OOM, forced restart) left the lock key behind forever. Because the poll results pull and contact sync tasks skip when the key exists, that permanently blocked syncing for the affected org or poll until the key was deleted manually.

- Archive results pull: new `POLL_PULL_ARCHIVES_LOCK_TIMEOUT` (12h) — this path has no pause/resume checkpoint, so its lease is sized to cover a full worst-case run rather than reusing the 2h value of the checkpointed API pull
- Reporters counter squash: 1h, matching the sibling squash tasks
- Contact counts rebuild: 12h, matching the org task lock on the same key
- Contact schemes backfill: 24h, matching its org task wrapper
- Contact count cache update: 20m, matching its org task wrapper

Note for operators: lock keys created before this change have no TTL and never expire on their own — after deploying, any lingering task lock keys with no TTL should be deleted once.