### PR TITLE
Restrict custom_html org config to superusers

### DIFF
--- a/ureport/public/tests.py
+++ b/ureport/public/tests.py
@@ -48,7 +48,7 @@ class PublicTest(UreportTest):
         self.login(self.admin)
         response = self.client.get(edit_url, SERVER_NAME="nigeria.ureport.io")
         self.assertTrue("form" in response.context)
-        self.assertEqual(len(response.context["form"].fields), 47)
+        self.assertEqual(len(response.context["form"].fields), 46)
 
         self.login(self.superuser)
         response = self.client.get(edit_url, SERVER_NAME="nigeria.ureport.io")

--- a/ureport/settings_common.py
+++ b/ureport/settings_common.py
@@ -653,6 +653,7 @@ ORG_CONFIG_FIELDS = [
             required=False,
             widget=Textarea,
         ),
+        superuser_only=True,
     ),
     dict(
         name="other_languages_sites",


### PR DESCRIPTION
The `custom_html` org config value is rendered on public pages inside an `{% autoescape off %}` block — it is the only org config field output raw — so whoever can edit it can inject arbitrary script into every visitor's browser. Unlike the other raw-output config fields it was not marked `superuser_only`, leaving it editable by any org administrator.

This gates it behind superuser like its siblings. Existing stored values continue to render on public pages, and an admin saving the org edit form does not clear them. Org admins keep the dedicated, properly-escaped analytics fields (Google Tag Manager, Google Analytics, Facebook Pixel) for the advertised use case.