### PR TITLE
Ignore unknown names in API ?fields and ?exclude params

### DIFF
--- a/ureport/api/serializers.py
+++ b/ureport/api/serializers.py
@@ -120,12 +120,12 @@ class StoryReadSerializer(serializers.ModelSerializer):
             # Drop any fields that are specified in the `exclude` argument.
             exclude_allowed = set(exclude_fields)
             for field_name in exclude_allowed:
-                self.fields.pop(field_name)
+                self.fields.pop(field_name, None)
         elif fields is not None:
             allowed_fields = set(fields)
             existing_data = set(self.fields)
             for field_names in existing_data - allowed_fields:
-                self.fields.pop(field_names)
+                self.fields.pop(field_names, None)
 
     class Meta:
         model = Story
@@ -165,12 +165,12 @@ class PollReadSerializer(serializers.ModelSerializer):
             # Drop any fields that are specified in the `exclude` argument.
             exclude_allowed = set(exclude_fields)
             for field_name in exclude_allowed:
-                self.fields.pop(field_name)
+                self.fields.pop(field_name, None)
         elif fields is not None:
             allowed_fields = set(fields)
             existing_data = set(self.fields)
             for field_names in existing_data - allowed_fields:
-                self.fields.pop(field_names)
+                self.fields.pop(field_names, None)
 
     def get_questions(self, obj):
         questions = []

--- a/ureport/api/tests.py
+++ b/ureport/api/tests.py
@@ -647,6 +647,30 @@ class UreportAPITests(APITestCase):
                 ),
             )
 
+    def test_polls_and_stories_with_unknown_field_parameters(self):
+        response = self.client.get("/api/v1/polls/%d/?exclude=bogus" % self.reg_poll.pk)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self.client.get("/api/v1/polls/%d/?fields=title,bogus" % self.reg_poll.pk)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertDictEqual(response.data, dict(title=self.reg_poll.title))
+
+        response = self.client.get("/api/v1/stories/%d/?exclude=bogus,title" % self.uganda_story.pk)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotIn("title", response.data)
+
+        response = self.client.get("/api/v1/stories/%d/?fields=title,bogus" % self.uganda_story.pk)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertDictEqual(response.data, dict(title=self.uganda_story.title))
+
+        # excluding every field is safe and returns an empty object
+        all_fields = ",".join(
+            ("id", "flow_uuid", "title", "org", "category", "poll_date", "modified_on", "created_on", "questions")
+        )
+        response = self.client.get("/api/v1/polls/%d/?exclude=%s" % (self.reg_poll.pk, all_fields))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertDictEqual(dict(response.data), dict())
+
     def test_news_item_by_org_list(self):
         url = "/api/v1/news/org/%d/" % self.uganda.pk
         url1 = "/api/v1/news/org/%d/" % self.nigeria.pk


### PR DESCRIPTION
`self.fields.pop(name)` without a default raised `KeyError` for any name that is not a serializer field, turning requests like `GET /api/v1/polls/1/?exclude=bogus` into 500s. Unknown names in `?fields` and `?exclude` are now ignored in both serializers that support these params.

Tests cover unknown names in both params for polls and stories, and the exclude-everything edge case returning an empty object.