### PR TITLE
Read SECRET_KEY from the DJANGO_SECRET_KEY environment variable

### DIFF
--- a/ureport/settings.py.prod
+++ b/ureport/settings.py.prod
@@ -12,6 +12,13 @@ DEBUG = False
 THUMBNAIL_DEBUG = DEBUG
 COMPRESS_ENABLED = True
 
+# fail on boot rather than fall back to the publicly-known development key
+SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
+
+# the previous signing key remains valid for verification only, so existing sessions
+# and tokens survive the rotation; remove it once they have all expired
+SECRET_KEY_FALLBACKS = ["bangbangrootplaydeadn7#^+-u-#1wm=y3a$-#^jps5tihx5v_@-_(kxumq_$+$5r)bxo"]
+
 
 EMPTY_SUBDOMAIN_HOST = 'http://ureport.in'
 HOSTNAME = 'ureport.in'

--- a/ureport/settings.py.staging
+++ b/ureport/settings.py.staging
@@ -11,6 +11,13 @@ DEBUG = False
 THUMBNAIL_DEBUG = DEBUG
 COMPRESS_ENABLED = True
 
+# fail on boot rather than fall back to the publicly-known development key
+SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
+
+# the previous signing key remains valid for verification only, so existing sessions
+# and tokens survive the rotation; remove it once they have all expired
+SECRET_KEY_FALLBACKS = ["bangbangrootplaydeadn7#^+-u-#1wm=y3a$-#^jps5tihx5v_@-_(kxumq_$+$5r)bxo"]
+
 EMPTY_SUBDOMAIN_HOST = 'http://nigeria.ureport.staging.nyaruka.com'
 HOSTNAME = 'ureport.staging.nyaruka.com'
 ALLOWED_HOSTS = ['.nyaruka.com', '.ureport.in']

--- a/ureport/settings_common.py
+++ b/ureport/settings_common.py
@@ -151,7 +151,9 @@ COMPRESS_PRECOMPILERS = (("text/less", "lessc {infile} {outfile}"),)
 
 # Make this unique, and don't share it with anybody. Deployments must set this
 # via the DJANGO_SECRET_KEY environment variable; the default is for development only.
-SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "bangbangrootplaydeadn7#^+-u-#1wm=y3a$-#^jps5tihx5v_@-_(kxumq_$+$5r)bxo")
+SECRET_KEY = os.environ.get(
+    "DJANGO_SECRET_KEY", "bangbangrootplaydeadn7#^+-u-#1wm=y3a$-#^jps5tihx5v_@-_(kxumq_$+$5r)bxo"
+)
 
 MIDDLEWARE = (
     "django.middleware.common.CommonMiddleware",

--- a/ureport/settings_common.py
+++ b/ureport/settings_common.py
@@ -149,8 +149,9 @@ STATICFILES_FINDERS = (
 
 COMPRESS_PRECOMPILERS = (("text/less", "lessc {infile} {outfile}"),)
 
-# Make this unique, and don't share it with anybody.
-SECRET_KEY = "bangbangrootplaydeadn7#^+-u-#1wm=y3a$-#^jps5tihx5v_@-_(kxumq_$+$5r)bxo"
+# Make this unique, and don't share it with anybody. Deployments must set this
+# via the DJANGO_SECRET_KEY environment variable; the default is for development only.
+SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "bangbangrootplaydeadn7#^+-u-#1wm=y3a$-#^jps5tihx5v_@-_(kxumq_$+$5r)bxo")
 
 MIDDLEWARE = (
     "django.middleware.common.CommonMiddleware",


### PR DESCRIPTION
The Django `SECRET_KEY` was a hardcoded literal committed to the repo, used to sign sessions, CSRF tokens, and password reset tokens.

- `settings_common.py` reads it from the `DJANGO_SECRET_KEY` environment variable, keeping the committed key only as a development fallback
- The production and staging settings variants require `DJANGO_SECRET_KEY` and fail on boot when it is missing, so a misconfigured deployment can never silently sign with the publicly-known key
- The old key is kept in `SECRET_KEY_FALLBACKS` for verification only, so existing sessions and password reset tokens survive the rotation — it should be removed in a follow-up once they have expired (sessions last two weeks)

Deploy note: `DJANGO_SECRET_KEY` must be provisioned in the environment (web and worker tiers alike, with the same value) before this change rolls out.