### PR TITLE
Remove SECRET_KEY_FALLBACKS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ jobs:
   test:
     name: Test (${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    env:
+      DJANGO_SECRET_KEY: ci-only-secret-key-not-used-anywhere-else
     strategy:
       matrix:
         python-version: ["3.14.x"]

--- a/ureport/settings.py.prod
+++ b/ureport/settings.py.prod
@@ -15,10 +15,6 @@ COMPRESS_ENABLED = True
 # fail on boot rather than fall back to the publicly-known development key
 SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
 
-# the previous signing key remains valid for verification only, so existing sessions
-# and tokens survive the rotation; remove it once they have all expired
-SECRET_KEY_FALLBACKS = ["bangbangrootplaydeadn7#^+-u-#1wm=y3a$-#^jps5tihx5v_@-_(kxumq_$+$5r)bxo"]
-
 
 EMPTY_SUBDOMAIN_HOST = 'http://ureport.in'
 HOSTNAME = 'ureport.in'

--- a/ureport/settings.py.staging
+++ b/ureport/settings.py.staging
@@ -14,10 +14,6 @@ COMPRESS_ENABLED = True
 # fail on boot rather than fall back to the publicly-known development key
 SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
 
-# the previous signing key remains valid for verification only, so existing sessions
-# and tokens survive the rotation; remove it once they have all expired
-SECRET_KEY_FALLBACKS = ["bangbangrootplaydeadn7#^+-u-#1wm=y3a$-#^jps5tihx5v_@-_(kxumq_$+$5r)bxo"]
-
 EMPTY_SUBDOMAIN_HOST = 'http://nigeria.ureport.staging.nyaruka.com'
 HOSTNAME = 'ureport.staging.nyaruka.com'
 ALLOWED_HOSTS = ['.nyaruka.com', '.ureport.in']

--- a/ureport/settings_common.py
+++ b/ureport/settings_common.py
@@ -151,9 +151,7 @@ COMPRESS_PRECOMPILERS = (("text/less", "lessc {infile} {outfile}"),)
 
 # Make this unique, and don't share it with anybody. Deployments must set this
 # via the DJANGO_SECRET_KEY environment variable; the default is for development only.
-SECRET_KEY = os.environ.get(
-    "DJANGO_SECRET_KEY", "bangbangrootplaydeadn7#^+-u-#1wm=y3a$-#^jps5tihx5v_@-_(kxumq_$+$5r)bxo"
-)
+SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "dev-only-secret-key-not-used-anywhere-else")
 
 MIDDLEWARE = (
     "django.middleware.common.CommonMiddleware",


### PR DESCRIPTION
Follow-up to #1365: drop the old signing key from `SECRET_KEY_FALLBACKS` in the production and staging settings variants, completing the key rotation in one step.

Deploy note: sessions and password reset tokens signed with the old key become invalid immediately on deploy — users with existing sessions will need to log in again.