### PR TITLE
Update smartmin to 6.1.0 and rapidpro-dash to 1.21.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ readme = "README.md"
 requires-python = ">=3.14.5,<3.15"
 dependencies = [
     "django>=6.0.6,<6.1",
-    "smartmin>=6.0.0,<6.1.0",
-    "rapidpro-dash>=1.20.0,<2.0.0",
+    "smartmin>=6.1.0,<6.2.0",
+    "rapidpro-dash>=1.21.0,<2.0.0",
     "colorama~=0.4.3",
     "celery[redis]>=5.5.3,<6.0.0",
     "django-compressor~=4.0",

--- a/ureport/backend/tests/test_rapidpro.py
+++ b/ureport/backend/tests/test_rapidpro.py
@@ -1167,7 +1167,7 @@ class RapidProBackendTest(UreportTest):
             ]
         )
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(9):
             field_results = self.backend.pull_fields(self.nigeria)
 
         self.assertEqual(
@@ -1286,7 +1286,7 @@ class RapidProBackendTest(UreportTest):
             ]
         )
 
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(8):
             boundaries_results = self.backend.pull_boundaries(self.nigeria)
 
         self.assertEqual(
@@ -1332,7 +1332,7 @@ class RapidProBackendTest(UreportTest):
             ]
         )
 
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(15):
             boundaries_results = self.backend.pull_boundaries(self.nigeria)
 
         self.assertEqual(

--- a/uv.lock
+++ b/uv.lock
@@ -708,7 +708,7 @@ wheels = [
 
 [[package]]
 name = "rapidpro-dash"
-version = "1.20.0"
+version = "1.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "celery", extra = ["redis"] },
@@ -724,9 +724,9 @@ dependencies = [
     { name = "smartmin" },
     { name = "sorl-thumbnail" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/23/c79c7a5aa54b13b3abdcb464cfb5158e809eed73231dd7c379a61da2c2fd/rapidpro_dash-1.20.0.tar.gz", hash = "sha256:727c1863e984a99c0bfdbc95b95e86821c1b527fcfb1ac23ca0fb7fa22c596d9", size = 726238, upload-time = "2026-04-06T16:58:40.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/18/9b62ba9fdadad1b16dac40af383cee4632fa5150cd8bf3415b8ae945a34e/rapidpro_dash-1.21.0.tar.gz", hash = "sha256:917a3c70442f04b8fd326ad437c5b61da271cb48a5fa31a9c204cfbca6d9af0a", size = 732201, upload-time = "2026-07-27T21:27:36.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/00/61c8c0b986041a50804ed98f4d1bcf245c9b1691d8d89a67628b254a9e17/rapidpro_dash-1.20.0-py3-none-any.whl", hash = "sha256:1576757d44ddbf0272aac2d82767753c9ecbbb44d5a4b325d432424728475ecd", size = 168184, upload-time = "2026-04-06T16:58:38.858Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/85/626f6b69b462947161c786169b4f02fa09677fd7f28d2e68bd5b31636d07/rapidpro_dash-1.21.0-py3-none-any.whl", hash = "sha256:2437cecdf72c78a6d2ada7d86a983c36016f88b2430029a7456e42255b925f9e", size = 169192, upload-time = "2026-07-27T21:27:35.112Z" },
 ]
 
 [[package]]
@@ -913,7 +913,7 @@ wheels = [
 
 [[package]]
 name = "smartmin"
-version = "6.0.1"
+version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
@@ -921,9 +921,9 @@ dependencies = [
     { name = "xlrd" },
     { name = "xlwt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/3d/2f9c2a7442335a5fbb5653c683e918a976c47733b512698aa3fea26b7ced/smartmin-6.0.1.tar.gz", hash = "sha256:1379059ba13c486113dd63fa5749ffb0da2a174b223d3d3857945d36f4e26207", size = 503431, upload-time = "2026-07-13T16:37:27.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/64/1b50519259470b9a5dcfb7f9cbdab7d9d8b40638343ec74eae59b3c6349d/smartmin-6.1.0.tar.gz", hash = "sha256:38e2cf29567cb578f7f589f083351c93c8a87985e0e3e07572640d0461e43bd9", size = 485925, upload-time = "2026-07-27T19:29:02.605Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/86/06f3e7cd595ad4c3f1ad3782b2af234e2247d9264abb8a5b0f5a3250f704/smartmin-6.0.1-py3-none-any.whl", hash = "sha256:4c23d6822487b19397aa4057ef4de83d196a52336b28bb69e427c7c499bf492f", size = 351568, upload-time = "2026-07-13T16:37:26.107Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b3/6a47e64f4d6b415f73a8aae9186fb9f435fa133a516911dc7fb2e55d3b7c/smartmin-6.1.0-py3-none-any.whl", hash = "sha256:525e989c40185d8a9ef2ef3db26a74b0c133fcd826784cda0f3bf388fce94d23", size = 351035, upload-time = "2026-07-27T19:29:01.304Z" },
 ]
 
 [[package]]
@@ -1048,11 +1048,11 @@ requires-dist = [
     { name = "pillow", specifier = "~=12.3.0" },
     { name = "psycopg", specifier = "~=3.2.3" },
     { name = "pycountry", specifier = ">=24.5.1" },
-    { name = "rapidpro-dash", specifier = ">=1.20.0,<2.0.0" },
+    { name = "rapidpro-dash", specifier = ">=1.21.0,<2.0.0" },
     { name = "rapidpro-python", specifier = ">=2.22.1,<3.0.0" },
     { name = "regex", specifier = "~=2026.4.4" },
     { name = "sentry-sdk", specifier = "~=2.19.2" },
-    { name = "smartmin", specifier = ">=6.0.0,<6.1.0" },
+    { name = "smartmin", specifier = ">=6.1.0,<6.2.0" },
     { name = "sorl-thumbnail", specifier = "~=12.11.0" },
     { name = "stop-words", specifier = "~=2018.7.23" },
     { name = "xlutils", specifier = "~=2.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -913,7 +913,7 @@ wheels = [
 
 [[package]]
 name = "smartmin"
-version = "6.0.0"
+version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
@@ -921,9 +921,9 @@ dependencies = [
     { name = "xlrd" },
     { name = "xlwt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/3b/e26f56c7fca369c1cf7e758a625393c1623a61afc203200616f43c4ca124/smartmin-6.0.0.tar.gz", hash = "sha256:3433d241ee9fffcbaa71101d82034cdf1c8e4699ff4f88bab291ff756049e13a", size = 503649, upload-time = "2026-04-06T16:09:23.55Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/3d/2f9c2a7442335a5fbb5653c683e918a976c47733b512698aa3fea26b7ced/smartmin-6.0.1.tar.gz", hash = "sha256:1379059ba13c486113dd63fa5749ffb0da2a174b223d3d3857945d36f4e26207", size = 503431, upload-time = "2026-07-13T16:37:27.445Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/3a/934f18557a5a4dd8d9a8fcfc5901d501d0c681ffd453a909076b50e919fa/smartmin-6.0.0-py3-none-any.whl", hash = "sha256:10d215f2449de6136a1b97ed1286c002e75872f7cf4f126877bf0b80e56d4e9a", size = 351600, upload-time = "2026-04-06T16:09:22.278Z" },
+    { url = "https://files.pythonhosted.org/packages/59/86/06f3e7cd595ad4c3f1ad3782b2af234e2247d9264abb8a5b0f5a3250f704/smartmin-6.0.1-py3-none-any.whl", hash = "sha256:4c23d6822487b19397aa4057ef4de83d196a52336b28bb69e427c7c499bf492f", size = 351568, upload-time = "2026-07-13T16:37:26.107Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updates smartmin 6.0.0 → 6.1.0 and rapidpro-dash 1.20.0 → 1.21.0 (which lifts the smartmin pin).

smartmin 6.1.0 includes several security fixes: open redirect via the `loc` form field, XSS in `VisibleHiddenWidget`, cryptographically secure password recovery tokens, and prevention of superuser/staff mimicking.

The dash sync helpers now perform an existence check before deletions, so the query-count assertions in the backend pull tests expect one more query per deleted object. Full test suite (167 tests) passes and locale files needed no regeneration.