### PR TITLE
Update rapidpro-dash to 1.21.1

### DIFF
--- a/code_check.py
+++ b/code_check.py
@@ -38,10 +38,10 @@ def update_po_files():
         return {e.msgid for e in pot if not e.fuzzy and not e.obsolete}
 
     if not path.exists("smartmin"):
-        cmd("""pip show smartmin | awk '/Location:/ { print $2 "/smartmin" }' | xargs ln -s""")
+        cmd("""uv pip show smartmin | awk '/Location:/ { print $2 "/smartmin" }' | xargs ln -sf""")
 
     if not path.exists("dash"):
-        cmd("""pip show rapidpro-dash | awk '/Location:/ { print $2 \"/dash\" }' | xargs ln -s""")
+        cmd("""uv pip show rapidpro-dash | awk '/Location:/ { print $2 \"/dash\" }' | xargs ln -sf""")
 
     # get the current set of msgids
     saved_msgids = get_current_msgids()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.14.5,<3.15"
 dependencies = [
     "django>=6.0.6,<6.1",
     "smartmin>=6.1.0,<6.2.0",
-    "rapidpro-dash>=1.21.0,<2.0.0",
+    "rapidpro-dash>=1.21.1,<2.0.0",
     "colorama~=0.4.3",
     "celery[redis]>=5.5.3,<6.0.0",
     "django-compressor~=4.0",

--- a/uv.lock
+++ b/uv.lock
@@ -708,7 +708,7 @@ wheels = [
 
 [[package]]
 name = "rapidpro-dash"
-version = "1.21.0"
+version = "1.21.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "celery", extra = ["redis"] },
@@ -724,9 +724,9 @@ dependencies = [
     { name = "smartmin" },
     { name = "sorl-thumbnail" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/18/9b62ba9fdadad1b16dac40af383cee4632fa5150cd8bf3415b8ae945a34e/rapidpro_dash-1.21.0.tar.gz", hash = "sha256:917a3c70442f04b8fd326ad437c5b61da271cb48a5fa31a9c204cfbca6d9af0a", size = 732201, upload-time = "2026-07-27T21:27:36.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/39/94385a0dd22cca420676b9b1edb42378cda8668f34937bedd2ff333ce60c/rapidpro_dash-1.21.1.tar.gz", hash = "sha256:7470eb3aa53fcc962928e2b6edd2642174c4c3d739862eb9fa95defc2b9c4634", size = 735681, upload-time = "2026-07-28T13:33:25.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/85/626f6b69b462947161c786169b4f02fa09677fd7f28d2e68bd5b31636d07/rapidpro_dash-1.21.0-py3-none-any.whl", hash = "sha256:2437cecdf72c78a6d2ada7d86a983c36016f88b2430029a7456e42255b925f9e", size = 169192, upload-time = "2026-07-27T21:27:35.112Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a7/bcffb2ddd523e76659be48df83c7927b0b5cc9d1519d44a1a8e7f13eea4a/rapidpro_dash-1.21.1-py3-none-any.whl", hash = "sha256:bfdb82fc9307f501c86ca1a7aa6167ebad96ad94aef86e77c9efca40d16f6b1b", size = 171337, upload-time = "2026-07-28T13:33:24.693Z" },
 ]
 
 [[package]]
@@ -1048,7 +1048,7 @@ requires-dist = [
     { name = "pillow", specifier = "~=12.3.0" },
     { name = "psycopg", specifier = "~=3.2.3" },
     { name = "pycountry", specifier = ">=24.5.1" },
-    { name = "rapidpro-dash", specifier = ">=1.21.0,<2.0.0" },
+    { name = "rapidpro-dash", specifier = ">=1.21.1,<2.0.0" },
     { name = "rapidpro-python", specifier = ">=2.22.1,<3.0.0" },
     { name = "regex", specifier = "~=2026.4.4" },
     { name = "sentry-sdk", specifier = "~=2.19.2" },


### PR DESCRIPTION
Updates rapidpro-dash 1.21.0 → 1.21.1, a bugfix release covering org task lock handling (non-blocking acquire with default expiry, guarded release), locale/timezone reset on requests without an org, and dashblock fixes.

Also fixes code_check.py's recreation of the dash/smartmin symlinks: it used `pip show`, which is not available in a uv-managed environment, so when the symlinks were missing locally the locale extraction silently ran without dash/smartmin templates and corrupted the locale files. It now uses `uv pip show` and `ln -sf`.

Full test suite (167 tests) passes; no locale changes needed.