### PR TITLE
Checkpoint sync progress after every fetched page and add optional sync time budget

### DIFF
--- a/ureport/backend/__init__.py
+++ b/ureport/backend/__init__.py
@@ -28,13 +28,18 @@ class BaseBackend(object):
         pass
 
     @abstractmethod
-    def pull_contacts(self, org, modified_after, modified_before, progress_callback=None):
+    def pull_contacts(
+        self, org, modified_after, modified_before, progress_callback=None, resume_cursor=None, time_limit=None
+    ):
         """
         Pulls contacts modified in the given time window
         :param org: the org
         :param datetime modified_after: pull contacts modified after this
         :param datetime modified_before: pull contacts modified before this
         :param progress_callback: callable that will be called from time to time with number of contacts pulled
-        :return: tuple of the number of contacts created, updated, deleted and ignored
+        :param resume_cursor: optional API cursor from a previous incomplete pull of the same time window
+        :param time_limit: optional number of seconds after which the pull pauses and returns a resume cursor
+        :return: tuple of a dict of counts of created, updated, deleted and ignored contacts, and a resume cursor
+                 if the pull didn't complete
         """
         pass

--- a/ureport/backend/floip.py
+++ b/ureport/backend/floip.py
@@ -186,7 +186,9 @@ class FLOIPBackend(BaseBackend):
         # Not needed
         return {SyncOutcome.created: 0, SyncOutcome.updated: 0, SyncOutcome.deleted: 0, SyncOutcome.ignored: 0}
 
-    def pull_contacts(self, org, modified_after, modified_before, progress_callback=None):
+    def pull_contacts(
+        self, org, modified_after, modified_before, progress_callback=None, resume_cursor=None, time_limit=None
+    ):
         client = self._get_client(org)
 
         # all contacts created or modified in the time window

--- a/ureport/backend/rapidpro.py
+++ b/ureport/backend/rapidpro.py
@@ -14,6 +14,7 @@ from django_valkey import get_valkey_connection
 from temba_client.exceptions import TembaRateExceededError
 from temba_client.v2.types import Run
 
+from django.conf import settings
 from django.core.cache import cache
 from django.utils import timezone
 
@@ -414,19 +415,21 @@ class RapidProBackend(BaseBackend):
 
         return sync_local_to_set(org, BoundarySyncer(backend=self.backend), incoming_objects)
 
-    def pull_contacts(self, org, modified_after, modified_before, progress_callback=None):
+    def pull_contacts(
+        self, org, modified_after, modified_before, progress_callback=None, resume_cursor=None, time_limit=None
+    ):
         client = self._get_client(org, 2)
 
         # all contacts created or modified in RapidPro in the time window
         active_query = client.get_contacts(after=modified_after, before=modified_before)
-        fetches = active_query.iterfetches(retry_on_rate_exceed=True)
+        fetches = active_query.iterfetches(retry_on_rate_exceed=True, resume_cursor=resume_cursor)
 
         # all contacts deleted in RapidPro in the same time window
         deleted_query = client.get_contacts(deleted=True, after=modified_after, before=modified_before)
         deleted_fetches = deleted_query.iterfetches(retry_on_rate_exceed=True)
 
         return sync_local_to_changes(
-            org, ContactSyncer(backend=self.backend), fetches, deleted_fetches, progress_callback
+            org, ContactSyncer(backend=self.backend), fetches, deleted_fetches, progress_callback, time_limit
         )
 
     def _iter_archive_records(self, archive, flow_uuid):
@@ -600,6 +603,9 @@ class RapidProBackend(BaseBackend):
                     pull_refresh_from_archives.apply_async((poll.pk,), queue="sync")
 
                 start = time.time()
+                time_budget = getattr(settings, "SYNC_TASK_TIME_BUDGET", None)
+                budget_expiration = start + time_budget if time_budget is not None else None
+
                 logger.info("Start fetching runs for poll #%d on org #%d" % (poll.pk, org.pk))
 
                 # fetch runs from API, respecting rate limits
@@ -656,6 +662,15 @@ class RapidProBackend(BaseBackend):
                         # Save the objects to the DB for new objects in the respective map
                         self._save_new_poll_results_to_database(poll_results_to_save_map)
 
+                        # runs are fetched oldest first, so once a page is saved the latest modified_on
+                        # seen is a valid resume point - persist it so an interrupted sync loses at most
+                        # one page of progress
+                        cache.set(
+                            Poll.POLL_RESULTS_LAST_PULL_CACHE_KEY % (org.pk, poll.flow_uuid),
+                            latest_synced_obj_time,
+                            None,
+                        )
+
                         logger.info(
                             "Processed fetch of %d - %d "
                             "runs for poll #%d on org #%d"
@@ -670,7 +685,11 @@ class RapidProBackend(BaseBackend):
                         logger.info("=" * 40)
 
                         # Pause the sync for this poll when we have synced Poll.POLL_RESULTS_MAX_SYNC_RUNS runs this time
-                        if stats_dict["num_synced"] >= Poll.POLL_RESULTS_MAX_SYNC_RUNS or time.time() > lock_expiration:
+                        if (
+                            stats_dict["num_synced"] >= Poll.POLL_RESULTS_MAX_SYNC_RUNS
+                            or time.time() > lock_expiration
+                            or (budget_expiration is not None and time.time() > budget_expiration)
+                        ):
                             # rebuild the aggregated counts
                             poll.rebuild_poll_results_counts()
 
@@ -1091,7 +1110,8 @@ class RapidProBackend(BaseBackend):
 
         from ureport.polls.tasks import pull_refresh
 
-        pull_refresh.apply_async((poll.pk,), countdown=300, queue="sync")
+        countdown = getattr(settings, "POLL_PULL_RESULTS_RESUME_COUNTDOWN", 300)
+        pull_refresh.apply_async((poll.pk,), countdown=countdown, queue="sync")
 
     @staticmethod
     def _mark_poll_results_sync_completed(poll, org, latest_synced_obj_time):

--- a/ureport/backend/tests/test_rapidpro.py
+++ b/ureport/backend/tests/test_rapidpro.py
@@ -1846,6 +1846,135 @@ class RapidProBackendTest(UreportTest):
         self.assertEqual(poll_result.category, "Win")
         self.assertEqual(poll_result.text, "We'll win today")
 
+    def _create_test_run(self, contact_uuid, modified_on):
+        return TembaRun.create(
+            uuid=contact_uuid,
+            flow=ObjectRef.create(uuid="flow-uuid", name="Flow 1"),
+            contact=ObjectRef.create(uuid=contact_uuid, name="Test"),
+            responded=True,
+            values={
+                "win": TembaRun.Value.create(
+                    value="We'll win today", category="Win", node="ruleset-uuid", time=modified_on
+                )
+            },
+            path=[TembaRun.Step.create(node="ruleset-uuid", time=modified_on)],
+            created_on=modified_on,
+            modified_on=modified_on,
+            exited_on=modified_on,
+            exit_type="completed",
+        )
+
+    @patch("valkey.client.StrictValkey.lock")
+    @patch("dash.orgs.models.TembaClient.get_runs")
+    @patch("django.core.cache.cache.set")
+    @patch("django.core.cache.cache.get")
+    def test_pull_results_checkpoints_watermark_after_each_page(
+        self, mock_cache_get, mock_cache_set, mock_get_runs, mock_valkey_lock
+    ):
+        mock_cache_get.return_value = None
+
+        PollResult.objects.all().delete()
+        poll = self.create_poll(self.nigeria, "Flow 1", "flow-uuid", self.education_nigeria, self.admin)
+        self.create_poll_question(self.admin, poll, "question 1", "ruleset-uuid")
+
+        now = timezone.now()
+        later = now + timedelta(minutes=5)
+
+        mock_get_runs.side_effect = [
+            MockClientQuery([self._create_test_run("C-001", now)], [self._create_test_run("C-002", later)])
+        ]
+
+        self.backend.pull_results(poll, None, None)
+
+        watermark_key = Poll.POLL_RESULTS_LAST_PULL_CACHE_KEY % (self.nigeria.pk, poll.flow_uuid)
+        watermark_writes = [call[0][1] for call in mock_cache_set.call_args_list if call[0][0] == watermark_key]
+
+        # one write per page saved plus the completion write
+        self.assertEqual(3, len(watermark_writes))
+        self.assertEqual(datetime_to_json_date(now), watermark_writes[0])
+        self.assertEqual(datetime_to_json_date(later), watermark_writes[1])
+        self.assertEqual(datetime_to_json_date(later), watermark_writes[2])
+
+    @override_settings(SYNC_TASK_TIME_BUDGET=0)
+    @patch("ureport.polls.tasks.pull_refresh.apply_async")
+    @patch("valkey.client.StrictValkey.lock")
+    @patch("dash.orgs.models.TembaClient.get_runs")
+    @patch("django.core.cache.cache.set")
+    @patch("django.core.cache.cache.get")
+    def test_pull_results_time_budget_pauses_after_page(
+        self, mock_cache_get, mock_cache_set, mock_get_runs, mock_valkey_lock, mock_pull_refresh
+    ):
+        mock_cache_get.return_value = None
+
+        PollResult.objects.all().delete()
+        poll = self.create_poll(self.nigeria, "Flow 1", "flow-uuid", self.education_nigeria, self.admin)
+        self.create_poll_question(self.admin, poll, "question 1", "ruleset-uuid")
+
+        now = timezone.now()
+        later = now + timedelta(minutes=5)
+
+        mock_get_runs.side_effect = [
+            MockClientQuery([self._create_test_run("C-001", now)], [self._create_test_run("C-002", later)])
+        ]
+
+        (
+            num_val_created,
+            num_val_updated,
+            num_val_ignored,
+            num_path_created,
+            num_path_updated,
+            num_path_ignored,
+        ) = self.backend.pull_results(poll, None, None)
+
+        # only the first page was processed before the budget expired
+        self.assertEqual(1, num_val_created)
+        self.assertEqual(1, PollResult.objects.all().count())
+
+        # the pause path checkpointed the first page and queued a resume
+        watermark_key = Poll.POLL_RESULTS_LAST_PULL_CACHE_KEY % (self.nigeria.pk, poll.flow_uuid)
+        watermark_writes = [call[0][1] for call in mock_cache_set.call_args_list if call[0][0] == watermark_key]
+        self.assertEqual([datetime_to_json_date(now), datetime_to_json_date(now)], watermark_writes)
+        mock_pull_refresh.assert_called_once_with((poll.pk,), countdown=300, queue="sync")
+
+    @patch("dash.orgs.models.TembaClient.get_contacts")
+    def test_pull_contacts_time_limit_returns_resume_cursor(self, mock_get_contacts):
+        Contact.objects.all().delete()
+
+        mock_get_contacts.side_effect = [
+            # two pages of active contacts
+            MockClientQuery(
+                [
+                    TembaContact.create(
+                        uuid="C-001",
+                        name="Bob McFlow",
+                        language="eng",
+                        urns=["twitter:bobflow"],
+                        groups=[ObjectRef.create(uuid="G-001", name="Customers")],
+                        fields={"age": "34"},
+                        status="active",
+                    )
+                ],
+                [
+                    TembaContact.create(
+                        uuid="C-002",
+                        name="Jim McMsg",
+                        language="fre",
+                        urns=["tel:+250783835665"],
+                        groups=[ObjectRef.create(uuid="G-002", name="Spammers")],
+                        fields={"age": "67"},
+                        status="active",
+                    )
+                ],
+            ),
+            # deleted contacts
+            MockClientQuery([]),
+        ]
+
+        contact_results, resume_cursor = self.backend.pull_contacts(self.nigeria, None, None, time_limit=0.000001)
+
+        # the pull paused after the first page and returned a cursor to resume from
+        self.assertEqual("cursor-string", resume_cursor)
+
     @patch("valkey.client.StrictValkey.lock")
     @patch("ureport.polls.models.Poll.get_flow_date")
     @patch("dash.orgs.models.TembaClient.get_archives")

--- a/ureport/contacts/models.py
+++ b/ureport/contacts/models.py
@@ -73,6 +73,10 @@ class Contact(models.Model):
     CONTACT_LAST_FETCHED_CACHE_KEY = "last:fetch_contacts:%d:backend:%s"
     CONTACT_LAST_FETCHED_CACHE_TIMEOUT = 60 * 60 * 24 * 30
 
+    # holds the API cursor and time window of an interrupted contacts pull so the next run
+    # can resume where it stopped instead of re-fetching the whole window
+    CONTACT_SYNC_RESUME_CACHE_KEY = "sync_resume:contacts:%d:backend:%s"
+
     MALE = "M"
     FEMALE = "F"
     OTHER = "O"

--- a/ureport/contacts/tasks.py
+++ b/ureport/contacts/tasks.py
@@ -5,6 +5,7 @@ import time
 from celery.utils.log import get_task_logger
 from django_valkey import get_valkey_connection
 
+from django.conf import settings
 from django.core.cache import cache
 from django.utils import timezone
 
@@ -89,9 +90,20 @@ def pull_contacts(org, ignored_since, ignored_until):
         backend = org.get_backend(backend_slug=backend_obj.slug)
 
         last_fetch_date_key = Contact.CONTACT_LAST_FETCHED_CACHE_KEY % (org.pk, backend_obj.slug)
+        sync_resume_key = Contact.CONTACT_SYNC_RESUME_CACHE_KEY % (org.pk, backend_obj.slug)
 
         until = datetime_to_json_date(timezone.now())
         since = cache.get(last_fetch_date_key, None)
+
+        resume_cursor = None
+        resume_state = cache.get(sync_resume_key, None)
+        if resume_state:
+            # the cursor is only valid for the query window it was created with, so resume
+            # the interrupted pull with its original bounds
+            since = resume_state.get("since")
+            until = resume_state.get("until")
+            resume_cursor = resume_state.get("cursor")
+            logger.info("Resuming interrupted contact pull for org #%d" % org.pk)
 
         if not since:
             logger.info("First time run for org #%d. Will sync all contacts" % org.pk)
@@ -130,14 +142,31 @@ def pull_contacts(org, ignored_since, ignored_until):
         logger.info("Fetch boundaries for org #%d took %ss" % (org.pk, time.time() - start_boundaries))
         start_contacts = time.time()
 
-        backend_contact_results, resume_cursor = backend.pull_contacts(org, since, until)
+        try:
+            backend_contact_results, next_resume_cursor = backend.pull_contacts(
+                org,
+                since,
+                until,
+                resume_cursor=resume_cursor,
+                time_limit=getattr(settings, "SYNC_TASK_TIME_BUDGET", None),
+            )
+        except Exception:
+            # a stored cursor may have expired on the API side - clear it so the next run
+            # falls back to a fresh pull of the same window instead of failing forever
+            cache.delete(sync_resume_key)
+            raise
 
         contacts_created = backend_contact_results[SyncOutcome.created]
         contacts_updated = backend_contact_results[SyncOutcome.updated]
         contacts_deleted = backend_contact_results[SyncOutcome.deleted]
         ignored = backend_contact_results[SyncOutcome.ignored]
 
-        cache.set(last_fetch_date_key, until, None)
+        if next_resume_cursor:
+            cache.set(sync_resume_key, {"cursor": next_resume_cursor, "since": since, "until": until}, None)
+            logger.info("Paused contact pull for org #%d, will resume next run" % org.pk)
+        else:
+            cache.delete(sync_resume_key)
+            cache.set(last_fetch_date_key, until, None)
 
         logger.info(
             "Fetched contacts for org #%d. "

--- a/ureport/contacts/tests.py
+++ b/ureport/contacts/tests.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 from mock import patch
 
+from django.core.cache import cache
 from django.utils import timezone
 
 from dash.orgs.models import TaskState
@@ -426,3 +427,54 @@ class ContactsTasksTest(UreportTest):
         )
 
         # mock_squash_counts.assert_called_once_with()
+
+    @patch("dash.orgs.models.Org.get_backend")
+    @patch("ureport.tests.TestBackend.pull_fields")
+    @patch("ureport.tests.TestBackend.pull_boundaries")
+    @patch("ureport.tests.TestBackend.pull_contacts")
+    def test_pull_contacts_resume_state(
+        self, mock_pull_contacts, mock_pull_boundaries, mock_pull_fields, mock_get_backend
+    ):
+        mock_get_backend.return_value = TestBackend(self.rapidpro_backend)
+        empty_counts = {SyncOutcome.created: 0, SyncOutcome.updated: 0, SyncOutcome.deleted: 0, SyncOutcome.ignored: 0}
+        mock_pull_fields.return_value = empty_counts
+        mock_pull_boundaries.return_value = empty_counts
+
+        # keep only one backend config
+        self.nigeria.backends.exclude(slug="rapidpro").delete()
+
+        last_fetch_key = Contact.CONTACT_LAST_FETCHED_CACHE_KEY % (self.nigeria.pk, "rapidpro")
+        resume_key = Contact.CONTACT_SYNC_RESUME_CACHE_KEY % (self.nigeria.pk, "rapidpro")
+        cache.delete(last_fetch_key)
+        cache.delete(resume_key)
+
+        # an interrupted pull stores its cursor and window, and does not advance the fetch watermark
+        mock_pull_contacts.return_value = (empty_counts, "cursor-1")
+        pull_contacts(self.nigeria.pk)
+
+        resume_state = cache.get(resume_key)
+        self.assertEqual("cursor-1", resume_state["cursor"])
+        self.assertIsNone(resume_state["since"])
+        self.assertIsNone(cache.get(last_fetch_key))
+
+        # the next run resumes the same window from the stored cursor
+        mock_pull_contacts.return_value = (empty_counts, None)
+        pull_contacts(self.nigeria.pk)
+
+        args, kwargs = mock_pull_contacts.call_args
+        self.assertEqual(resume_state["until"], args[2])
+        self.assertEqual("cursor-1", kwargs["resume_cursor"])
+
+        # completion clears the resume state and advances the fetch watermark to the window end
+        self.assertIsNone(cache.get(resume_key))
+        self.assertEqual(resume_state["until"], cache.get(last_fetch_key))
+
+        # a failing pull clears stored resume state so a stale cursor cannot wedge future syncs
+        mock_pull_contacts.return_value = (empty_counts, "cursor-2")
+        pull_contacts(self.nigeria.pk)
+        self.assertIsNotNone(cache.get(resume_key))
+
+        mock_pull_contacts.side_effect = ValueError("boom")
+        with self.assertRaises(ValueError):
+            pull_contacts(self.nigeria.pk)
+        self.assertIsNone(cache.get(resume_key))

--- a/ureport/polls/tasks.py
+++ b/ureport/polls/tasks.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from django_valkey import get_valkey_connection
 from temba_client.exceptions import TembaRateExceededError
 
+from django.conf import settings
 from django.core.cache import cache
 from django.utils import timezone
 
@@ -24,11 +25,22 @@ from ureport.utils import (
 logger = logging.getLogger(__name__)
 
 
+def _sync_deadline():
+    """
+    Returns the time after which a sync task should stop starting new polls, or None if
+    no time budget is configured. Scheduled tasks are re-triggered by beat, so remaining
+    polls are picked up on the next cycle.
+    """
+    time_budget = getattr(settings, "SYNC_TASK_TIME_BUDGET", None)
+    return time.time() + time_budget if time_budget is not None else None
+
+
 @org_task("backfill-poll-results", 60 * 60 * 3)
 def backfill_poll_results(org, since, until):
     from .models import Poll
 
     results_log = dict()
+    deadline = _sync_deadline()
 
     for poll in (
         Poll.objects.filter(org=org, has_synced=False)
@@ -36,6 +48,9 @@ def backfill_poll_results(org, since, until):
         .exclude(flow_uuid="")
         .distinct("flow_uuid")
     ):
+        if deadline is not None and time.time() > deadline:
+            logger.info("Time budget exhausted backfilling results for org #%d, will resume next cycle" % org.id)
+            break
         (
             num_val_created,
             num_val_updated,
@@ -94,7 +109,11 @@ def pull_results_other_polls(org, since, until):
     other_polls_ids = Poll.get_other_polls(org).exclude(created_on__gt=recent_window)
     other_polls_ids = other_polls_ids.order_by("flow_uuid").distinct("flow_uuid").values_list("id", flat=True)
     other_polls = Poll.objects.filter(id__in=other_polls_ids).order_by("-created_on")
+    deadline = _sync_deadline()
     for poll in other_polls:
+        if deadline is not None and time.time() > deadline:
+            logger.info("Time budget exhausted pulling other polls for org #%d, will resume next cycle" % org.id)
+            break
         key = Poll.POLL_RESULTS_LAST_OTHER_POLLS_SYNCED_CACHE_KEY % (org.id, poll.flow_uuid)
         if not cache.get(key):
             try:
@@ -131,7 +150,11 @@ def pull_results_recent_polls(org, since, until):
     recent_polls_ids = recent_polls_ids.distinct("flow_uuid").values_list("id", flat=True)
 
     recent_polls = Poll.objects.filter(id__in=recent_polls_ids).order_by("-created_on")
+    deadline = _sync_deadline()
     for poll in recent_polls:
+        if deadline is not None and time.time() > deadline:
+            logger.info("Time budget exhausted pulling recent polls for org #%d, will resume next cycle" % org.id)
+            break
         (
             num_val_created,
             num_val_updated,

--- a/ureport/polls/tests.py
+++ b/ureport/polls/tests.py
@@ -14,6 +14,7 @@ from django.db.models import Count, ExpressionWrapper, F, IntegerField, Sum, Tex
 from django.db.models.functions import Cast, ExtractYear
 from django.http import HttpRequest
 from django.template import TemplateSyntaxError
+from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -30,6 +31,7 @@ from ureport.polls.tasks import (
     pull_refresh,
     pull_results_main_poll,
     pull_results_other_polls,
+    pull_results_recent_polls,
     rebuild_counts,
     recheck_poll_flow_data,
     refresh_org_flows,
@@ -3214,6 +3216,41 @@ class PollsTasksTest(UreportTest):
         task_state = TaskState.objects.get(org=self.nigeria, task_key="results-pull-other-polls")
         self.assertEqual(task_state.get_last_results(), {})
         mock_pull_results.assert_called_once()
+
+    @override_settings(SYNC_TASK_TIME_BUDGET=0)
+    @patch("ureport.polls.models.Poll.get_flow_date")
+    @patch("dash.orgs.models.Org.get_backend")
+    @patch("ureport.tests.TestBackend.pull_results")
+    def test_backfill_poll_results_time_budget(self, mock_pull_results, mock_get_backend, mock_get_flow_date):
+        mock_get_backend.return_value = TestBackend(self.rapidpro_backend)
+        mock_pull_results.return_value = (1, 2, 3, 4, 5, 6)
+        mock_get_flow_date.return_value = None
+
+        self.poll.has_synced = False
+        self.poll.save()
+
+        # with an exhausted time budget no poll sync is started, leaving the rest for the next cycle
+        backfill_poll_results(self.nigeria.pk)
+        self.assertFalse(mock_pull_results.called)
+
+        task_state = TaskState.objects.get(org=self.nigeria, task_key="backfill-poll-results")
+        self.assertEqual(task_state.get_last_results(), {})
+
+    @override_settings(SYNC_TASK_TIME_BUDGET=0)
+    @patch("ureport.polls.models.Poll.get_flow_date")
+    @patch("dash.orgs.models.Org.get_backend")
+    @patch("ureport.tests.TestBackend.pull_results")
+    @patch("ureport.polls.models.Poll.get_recent_polls")
+    def test_pull_results_recent_polls_time_budget(
+        self, mock_get_recent_polls, mock_pull_results, mock_get_backend, mock_get_flow_date
+    ):
+        mock_get_backend.return_value = TestBackend(self.rapidpro_backend)
+        mock_get_recent_polls.return_value = self.polls_query
+        mock_pull_results.return_value = (1, 2, 3, 4, 5, 6)
+        mock_get_flow_date.return_value = None
+
+        pull_results_recent_polls(self.nigeria.pk)
+        self.assertFalse(mock_pull_results.called)
 
     @patch("ureport.polls.models.Poll.get_flow_date")
     @patch("dash.orgs.models.Org.get_backend")

--- a/ureport/settings_common.py
+++ b/ureport/settings_common.py
@@ -949,6 +949,19 @@ DEFAULT_COUNTRY_CODE = "250"
 INTERNAL_IPS = ("127.0.0.1",)
 
 # -----------------------------------------------------------------------------------
+# Sync Settings
+# -----------------------------------------------------------------------------------
+
+# maximum seconds a single sync task invocation may spend fetching before it pauses,
+# checkpoints its progress and lets a future run resume - None disables the budget.
+# Set this comfortably below the worker's shutdown grace period when workers are
+# short-lived (e.g. 90 for containers stopped after 120s)
+SYNC_TASK_TIME_BUDGET = None
+
+# countdown in seconds before a paused poll results sync is re-queued
+POLL_PULL_RESULTS_RESUME_COUNTDOWN = 300
+
+# -----------------------------------------------------------------------------------
 # Crontab Settings
 # -----------------------------------------------------------------------------------
 


### PR DESCRIPTION
Part 1 of a 4-PR stack making the sync tasks resilient to short-lived workers (e.g. containers that are stopped with a bounded grace period).

Poll results pulls previously persisted their resume watermark (\`latest_synced_obj_time\`) only when hitting the max-runs cap, lock expiry, or completion — so a worker killed mid-sync lost the whole window's progress and re-fetched the same API pages on every attempt. Contact pulls had the same problem at phase granularity.

Changes:
- \`RapidProBackend.pull_results\` persists the watermark after **every** saved page. Runs are fetched oldest-first, so each page's max \`modified_on\` is a valid resume point — an interrupted sync now loses at most one page.
- New \`SYNC_TASK_TIME_BUDGET\` setting (default \`None\` = unchanged behavior): when set, a sync invocation pauses after that many seconds via the existing pause/requeue path (rebuild counts, mark paused, requeue \`pull_refresh\`).
- The paused-poll requeue countdown is now configurable via \`POLL_PULL_RESULTS_RESUME_COUNTDOWN\` (default 300s, unchanged).
- \`pull_contacts\` passes the budget as \`time_limit\` to dash's \`sync_local_to_changes\` and stores the returned API resume cursor together with its query window; the next run resumes from the cursor instead of re-fetching the window. A failing pull clears the stored cursor so a stale cursor can't wedge future syncs.
- \`backfill_poll_results\`, \`pull_results_recent_polls\` and \`pull_results_other_polls\` stop starting new polls once the budget is exhausted, leaving the rest to the next beat cycle.

Tests cover per-page watermark writes, the budget pause path, cursor persistence/resume/clear, and the loop deadline behavior.