### PR TITLE
Free sync locks quickly after a killed worker

### DIFF
--- a/ureport/backend/rapidpro.py
+++ b/ureport/backend/rapidpro.py
@@ -7,12 +7,14 @@ import json
 import logging
 import time
 from collections import defaultdict
+from contextlib import contextmanager
 from datetime import timedelta, timezone as tzone
 
 import requests
 from django_valkey import get_valkey_connection
 from temba_client.exceptions import TembaRateExceededError
 from temba_client.v2.types import Run
+from valkey.exceptions import LockError
 
 from django.conf import settings
 from django.core.cache import cache
@@ -557,6 +559,25 @@ class RapidProBackend(BaseBackend):
             stats_dict["num_path_ignored"],
         )
 
+    @staticmethod
+    @contextmanager
+    def _owned_lock(lock, poll, org):
+        """
+        Acquires the given lock for the duration of the block, tolerating a lease that expired
+        before release - the work is already done at that point and must not be failed for it
+        """
+        lock.acquire()
+        try:
+            yield lock
+        finally:
+            try:
+                lock.release()
+            except LockError:
+                logger.warning(
+                    "Unable to release pull results lock for poll #%d on org #%d as it is no longer owned"
+                    % (poll.pk, org.pk)
+                )
+
     def pull_results(self, poll, modified_after, modified_before, progress_callback=None):
         org = poll.org
         r = get_valkey_connection()
@@ -585,7 +606,10 @@ class RapidProBackend(BaseBackend):
         if r.get(key):
             logger.info("Skipping pulling results for poll #%d on org #%d as it is still running" % (poll.pk, org.pk))
         else:
-            with r.lock(key, timeout=Poll.POLL_SYNC_LOCK_TIMEOUT):
+            # the lock lease is short and renewed after every page, so a killed worker frees the
+            # poll within minutes; the sync itself may still run much longer than the lease
+            lock = r.lock(key, timeout=Poll.POLL_PULL_RESULTS_LOCK_TIMEOUT)
+            with self._owned_lock(lock, poll, org):
                 lock_expiration = time.time() + 0.8 * Poll.POLL_SYNC_LOCK_TIMEOUT
                 client = self._get_client(org, 2)
 
@@ -618,6 +642,27 @@ class RapidProBackend(BaseBackend):
                     fetch_start = time.time()
 
                     for fetch in fetches:
+                        try:
+                            lock.extend(Poll.POLL_PULL_RESULTS_LOCK_TIMEOUT, replace_ttl=True)
+                        except LockError:
+                            # our lease expired and another worker may now own this poll - pause
+                            # at the last saved page rather than risk two concurrent syncs
+                            poll.rebuild_poll_results_counts()
+                            self._mark_poll_results_sync_paused(org, poll, latest_synced_obj_time)
+
+                            logger.warning(
+                                "Lost pull results lock for poll #%d on org #%d, pausing sync" % (poll.pk, org.pk)
+                            )
+
+                            return (
+                                stats_dict["num_val_created"],
+                                stats_dict["num_val_updated"],
+                                stats_dict["num_val_ignored"],
+                                stats_dict["num_path_created"],
+                                stats_dict["num_path_updated"],
+                                stats_dict["num_path_ignored"],
+                            )
+
                         logger.info(
                             "RapidPro API fetch for poll #%d "
                             "on org #%d %d - %d took %ds"

--- a/ureport/backend/tests/test_rapidpro.py
+++ b/ureport/backend/tests/test_rapidpro.py
@@ -1393,7 +1393,8 @@ class RapidProBackendTest(UreportTest):
         )
         mock_get_runs.assert_called_with(flow="flow-uuid", after=None, reverse=True, paths=True)
         mock_valkey_lock.assert_called_once_with(
-            Poll.POLL_PULL_RESULTS_TASK_LOCK % (poll.org.pk, poll.flow_uuid), timeout=7200
+            Poll.POLL_PULL_RESULTS_TASK_LOCK % (poll.org.pk, poll.flow_uuid),
+            timeout=Poll.POLL_PULL_RESULTS_LOCK_TIMEOUT,
         )
 
         poll_result = PollResult.objects.filter(flow="flow-uuid", ruleset="ruleset-uuid", contact="C-001").first()
@@ -1931,6 +1932,74 @@ class RapidProBackendTest(UreportTest):
         self.assertEqual(1, PollResult.objects.all().count())
 
         # the pause path checkpointed the first page and queued a resume
+        watermark_key = Poll.POLL_RESULTS_LAST_PULL_CACHE_KEY % (self.nigeria.pk, poll.flow_uuid)
+        watermark_writes = [call[0][1] for call in mock_cache_set.call_args_list if call[0][0] == watermark_key]
+        self.assertEqual([datetime_to_json_date(now), datetime_to_json_date(now)], watermark_writes)
+        mock_pull_refresh.assert_called_once_with((poll.pk,), countdown=300, queue="sync")
+
+    @patch("valkey.client.StrictValkey.lock")
+    @patch("dash.orgs.models.TembaClient.get_runs")
+    @patch("django.core.cache.cache.set")
+    @patch("django.core.cache.cache.get")
+    def test_pull_results_renews_lock_each_page(self, mock_cache_get, mock_cache_set, mock_get_runs, mock_valkey_lock):
+        mock_cache_get.return_value = None
+
+        PollResult.objects.all().delete()
+        poll = self.create_poll(self.nigeria, "Flow 1", "flow-uuid", self.education_nigeria, self.admin)
+        self.create_poll_question(self.admin, poll, "question 1", "ruleset-uuid")
+
+        now = timezone.now()
+        later = now + timedelta(minutes=5)
+
+        mock_get_runs.side_effect = [
+            MockClientQuery([self._create_test_run("C-001", now)], [self._create_test_run("C-002", later)])
+        ]
+
+        self.backend.pull_results(poll, None, None)
+
+        mock_lock = mock_valkey_lock.return_value
+        self.assertEqual(2, mock_lock.extend.call_count)
+        mock_lock.extend.assert_called_with(Poll.POLL_PULL_RESULTS_LOCK_TIMEOUT, replace_ttl=True)
+
+    @patch("ureport.polls.tasks.pull_refresh.apply_async")
+    @patch("valkey.client.StrictValkey.lock")
+    @patch("dash.orgs.models.TembaClient.get_runs")
+    @patch("django.core.cache.cache.set")
+    @patch("django.core.cache.cache.get")
+    def test_pull_results_pauses_when_lock_lost(
+        self, mock_cache_get, mock_cache_set, mock_get_runs, mock_valkey_lock, mock_pull_refresh
+    ):
+        from valkey.exceptions import LockNotOwnedError
+
+        mock_cache_get.return_value = None
+
+        PollResult.objects.all().delete()
+        poll = self.create_poll(self.nigeria, "Flow 1", "flow-uuid", self.education_nigeria, self.admin)
+        self.create_poll_question(self.admin, poll, "question 1", "ruleset-uuid")
+
+        now = timezone.now()
+        later = now + timedelta(minutes=5)
+
+        mock_get_runs.side_effect = [
+            MockClientQuery([self._create_test_run("C-001", now)], [self._create_test_run("C-002", later)])
+        ]
+
+        # first renewal succeeds, second finds the lease expired
+        mock_valkey_lock.return_value.extend.side_effect = [True, LockNotOwnedError("expired")]
+
+        (
+            num_val_created,
+            num_val_updated,
+            num_val_ignored,
+            num_path_created,
+            num_path_updated,
+            num_path_ignored,
+        ) = self.backend.pull_results(poll, None, None)
+
+        # only the first page was processed, then the sync paused at the saved watermark
+        self.assertEqual(1, num_val_created)
+        self.assertEqual(1, PollResult.objects.all().count())
+
         watermark_key = Poll.POLL_RESULTS_LAST_PULL_CACHE_KEY % (self.nigeria.pk, poll.flow_uuid)
         watermark_writes = [call[0][1] for call in mock_cache_set.call_args_list if call[0][0] == watermark_key]
         self.assertEqual([datetime_to_json_date(now), datetime_to_json_date(now)], watermark_writes)

--- a/ureport/contacts/tasks.py
+++ b/ureport/contacts/tasks.py
@@ -15,7 +15,7 @@ from dash.utils.sync import SyncOutcome
 from ureport.celery import app
 from ureport.contacts.models import Contact, ReportersCounter
 from ureport.stats.models import ContactActivity
-from ureport.utils import chunk_list, datetime_to_json_date, update_cache_org_contact_counts
+from ureport.utils import chunk_list, datetime_to_json_date, org_sync_lock_timeout, update_cache_org_contact_counts
 
 logger = get_task_logger(__name__)
 
@@ -76,7 +76,7 @@ def update_org_contact_count(org, ignored_since, ignored_until):
     update_cache_org_contact_counts(org)
 
 
-@org_task("contact-pull", 60 * 60 * 12)
+@org_task("contact-pull", org_sync_lock_timeout(60 * 60 * 12))
 def pull_contacts(org, ignored_since, ignored_until):
     """
     Fetches updated contacts from RapidPro and updates local contacts accordingly

--- a/ureport/polls/models.py
+++ b/ureport/polls/models.py
@@ -101,6 +101,10 @@ class Poll(SmartModel):
 
     POLL_SYNC_LOCK_TIMEOUT = 60 * 60 * 2
 
+    # lease of the results pull lock - renewed after every fetched page, so it only needs to
+    # outlive a single page; a killed worker frees the poll within this time instead of hours
+    POLL_PULL_RESULTS_LOCK_TIMEOUT = 60 * 10
+
     # archive pulls have no pause/resume checkpoint so their lock lease must cover a full worst-case run
     POLL_PULL_ARCHIVES_LOCK_TIMEOUT = 60 * 60 * 12
 

--- a/ureport/polls/tasks.py
+++ b/ureport/polls/tasks.py
@@ -18,6 +18,7 @@ from ureport.utils import (
     fetch_flows,
     fetch_old_sites_count as do_fetch_old_sites_count,
     fetch_shared_sites_count,
+    org_sync_lock_timeout,
     populate_age_and_gender_poll_results,
     update_poll_flow_data,
 )
@@ -35,7 +36,7 @@ def _sync_deadline():
     return time.time() + time_budget if time_budget is not None else None
 
 
-@org_task("backfill-poll-results", 60 * 60 * 3)
+@org_task("backfill-poll-results", org_sync_lock_timeout(60 * 60 * 3))
 def backfill_poll_results(org, since, until):
     from .models import Poll
 
@@ -71,7 +72,7 @@ def backfill_poll_results(org, since, until):
     return results_log
 
 
-@org_task("results-pull-main-poll", 60 * 60 * 2)
+@org_task("results-pull-main-poll", org_sync_lock_timeout(60 * 60 * 2))
 def pull_results_main_poll(org, since, until):
     from .models import Poll
 
@@ -98,7 +99,7 @@ def pull_results_main_poll(org, since, until):
     return results_log
 
 
-@org_task("results-pull-other-polls", 60 * 60 * 24)
+@org_task("results-pull-other-polls", org_sync_lock_timeout(60 * 60 * 24))
 def pull_results_other_polls(org, since, until):
     from .models import Poll
 
@@ -141,7 +142,7 @@ def pull_results_other_polls(org, since, until):
     return results_log
 
 
-@org_task("results-pull-recent-polls", 60 * 60 * 6)
+@org_task("results-pull-recent-polls", org_sync_lock_timeout(60 * 60 * 6))
 def pull_results_recent_polls(org, since, until):
     from .models import Poll
 

--- a/ureport/utils/__init__.py
+++ b/ureport/utils/__init__.py
@@ -134,6 +134,19 @@ def chunk_list(iterable, size):
             return
 
 
+def org_sync_lock_timeout(default_timeout):
+    """
+    Lock timeout for an org sync task. When a sync time budget is configured, invocations pause
+    within the budget so a much shorter lock is enough, and a killed worker then frees the org in
+    minutes rather than hours. Without a budget, runs can legitimately be long-lived and need the
+    full default. Evaluated at import time, so changing the budget requires a restart.
+    """
+    time_budget = getattr(settings, "SYNC_TASK_TIME_BUDGET", None)
+    if time_budget is not None:
+        return max(int(time_budget) * 4, 60 * 10)
+    return default_timeout
+
+
 def get_logo(org):
     if hasattr(org, "_logo_field"):
         return org._logo_field

--- a/ureport/utils/tests.py
+++ b/ureport/utils/tests.py
@@ -10,6 +10,7 @@ from mock import patch
 from temba_client.v2 import Flow
 
 from django.conf import settings
+from django.test import override_settings
 from django.utils import timezone
 
 from dash.categories.models import Category
@@ -35,6 +36,7 @@ from ureport.utils import (
     get_reporters_count,
     get_ureporters_locations_stats,
     json_date_to_datetime,
+    org_sync_lock_timeout,
     update_poll_flow_data,
 )
 
@@ -68,6 +70,18 @@ class UtilsTest(UreportTest):
         self.assertEqual(json_date_to_datetime("2014-01-02T03:04:05+02:00"), d2)
         self.assertEqual(json_date_to_datetime("2014-01-02T01:04:05.000Z"), d2)
         self.assertEqual(json_date_to_datetime("2014-01-02T01:04:05.000"), d2)
+
+    def test_org_sync_lock_timeout(self):
+        # without a time budget, tasks keep their long lock timeouts
+        with override_settings(SYNC_TASK_TIME_BUDGET=None):
+            self.assertEqual(60 * 60 * 12, org_sync_lock_timeout(60 * 60 * 12))
+
+        # with a budget, the lock only needs to outlive a short run
+        with override_settings(SYNC_TASK_TIME_BUDGET=90):
+            self.assertEqual(60 * 10, org_sync_lock_timeout(60 * 60 * 12))
+
+        with override_settings(SYNC_TASK_TIME_BUDGET=300):
+            self.assertEqual(1200, org_sync_lock_timeout(60 * 60 * 12))
 
     @mock.patch("ureport.utils.get_shared_sites_count")
     def test_get_linked_orgs(self, mock_get_shared_sites_count):


### PR DESCRIPTION
Part 2 of the sync-resilience stack, on top of #1369.

A hard-killed worker never runs its \`finally\` blocks, so the valkey locks guarding poll and org syncs stayed held for their full timeout — two hours for a poll pull, up to 24 hours for org tasks — silencing that poll/org's sync for the duration.

Changes:
- The poll results pull lock now uses a short lease (\`POLL_PULL_RESULTS_LOCK_TIMEOUT\`, 10 min) renewed with \`lock.extend\` after every fetched page. A killed worker frees the poll within minutes; a live long-running sync keeps holding it.
- If a renewal finds the lease expired (another worker may own the poll), the sync pauses at its last saved page instead of continuing concurrently.
- Lock release tolerates an already-expired lease — completed work is not failed for it.
- Org sync task lock timeouts are derived from \`SYNC_TASK_TIME_BUDGET\` via \`org_sync_lock_timeout()\`: with a budget configured, runs are short so locks shrink accordingly (≥10 min); without one, the long defaults are kept. This ties the shortened locks to the mechanism that guarantees short runs, so the two can't be deployed apart.
- Locks held across monolithic work with no renewal point (archive pulls, clearing old results) keep their full leases.