### PR TITLE
Pause sync loops cleanly when the worker is shutting down

### DIFF
--- a/ureport/backend/rapidpro.py
+++ b/ureport/backend/rapidpro.py
@@ -28,6 +28,7 @@ from ureport.locations.models import Boundary
 from ureport.polls.models import Poll, PollQuestion, PollResponseCategory, PollResult
 from ureport.polls.tasks import pull_refresh_from_archives
 from ureport.stats.models import ContactActivity
+from ureport.sync_state import is_sync_shutting_down
 from ureport.utils import chunk_list, datetime_to_json_date, json_date_to_datetime
 
 from . import BaseBackend
@@ -734,6 +735,7 @@ class RapidProBackend(BaseBackend):
                             stats_dict["num_synced"] >= Poll.POLL_RESULTS_MAX_SYNC_RUNS
                             or time.time() > lock_expiration
                             or (budget_expiration is not None and time.time() > budget_expiration)
+                            or is_sync_shutting_down()
                         ):
                             # rebuild the aggregated counts
                             poll.rebuild_poll_results_counts()

--- a/ureport/backend/tests/test_rapidpro.py
+++ b/ureport/backend/tests/test_rapidpro.py
@@ -2005,6 +2005,43 @@ class RapidProBackendTest(UreportTest):
         self.assertEqual([datetime_to_json_date(now), datetime_to_json_date(now)], watermark_writes)
         mock_pull_refresh.assert_called_once_with((poll.pk,), countdown=300, queue="sync")
 
+    @patch("ureport.backend.rapidpro.is_sync_shutting_down")
+    @patch("ureport.polls.tasks.pull_refresh.apply_async")
+    @patch("valkey.client.StrictValkey.lock")
+    @patch("dash.orgs.models.TembaClient.get_runs")
+    @patch("django.core.cache.cache.set")
+    @patch("django.core.cache.cache.get")
+    def test_pull_results_pauses_on_worker_shutdown(
+        self, mock_cache_get, mock_cache_set, mock_get_runs, mock_valkey_lock, mock_pull_refresh, mock_shutting_down
+    ):
+        mock_cache_get.return_value = None
+        mock_shutting_down.return_value = True
+
+        PollResult.objects.all().delete()
+        poll = self.create_poll(self.nigeria, "Flow 1", "flow-uuid", self.education_nigeria, self.admin)
+        self.create_poll_question(self.admin, poll, "question 1", "ruleset-uuid")
+
+        now = timezone.now()
+        later = now + timedelta(minutes=5)
+
+        mock_get_runs.side_effect = [
+            MockClientQuery([self._create_test_run("C-001", now)], [self._create_test_run("C-002", later)])
+        ]
+
+        (
+            num_val_created,
+            num_val_updated,
+            num_val_ignored,
+            num_path_created,
+            num_path_updated,
+            num_path_ignored,
+        ) = self.backend.pull_results(poll, None, None)
+
+        # the sync paused at the first saved page instead of continuing into the shutdown
+        self.assertEqual(1, num_val_created)
+        self.assertEqual(1, PollResult.objects.all().count())
+        mock_pull_refresh.assert_called_once_with((poll.pk,), countdown=300, queue="sync")
+
     @patch("dash.orgs.models.TembaClient.get_contacts")
     def test_pull_contacts_time_limit_returns_resume_cursor(self, mock_get_contacts):
         Contact.objects.all().delete()

--- a/ureport/celery.py
+++ b/ureport/celery.py
@@ -3,6 +3,7 @@
 import os
 
 from celery import Celery
+from celery.signals import worker_ready, worker_shutting_down
 
 from django.conf import settings
 
@@ -16,3 +17,22 @@ app = Celery("ureport")
 # pickle the object when using Windows.
 app.config_from_object("django.conf:settings", namespace="CELERY")
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+
+
+@worker_shutting_down.connect
+def flag_sync_shutdown(**kwargs):
+    """
+    The shutdown signal only reaches the worker main process while sync tasks run in pool
+    child processes, so flag the shutdown in the shared cache where sync loops can see it
+    and pause at their next checkpoint
+    """
+    from ureport.sync_state import signal_sync_shutdown
+
+    signal_sync_shutdown()
+
+
+@worker_ready.connect
+def reset_sync_shutdown(**kwargs):
+    from ureport.sync_state import clear_sync_shutdown
+
+    clear_sync_shutdown()

--- a/ureport/polls/tasks.py
+++ b/ureport/polls/tasks.py
@@ -14,6 +14,7 @@ from django.utils import timezone
 from dash.orgs.models import Org
 from dash.orgs.tasks import org_task
 from ureport.celery import app
+from ureport.sync_state import is_sync_shutting_down
 from ureport.utils import (
     fetch_flows,
     fetch_old_sites_count as do_fetch_old_sites_count,
@@ -36,6 +37,14 @@ def _sync_deadline():
     return time.time() + time_budget if time_budget is not None else None
 
 
+def _sync_should_stop(deadline):
+    """
+    Whether a sync loop should stop starting new polls - either its time budget ran out or
+    the worker is shutting down
+    """
+    return (deadline is not None and time.time() > deadline) or is_sync_shutting_down()
+
+
 @org_task("backfill-poll-results", org_sync_lock_timeout(60 * 60 * 3))
 def backfill_poll_results(org, since, until):
     from .models import Poll
@@ -49,8 +58,8 @@ def backfill_poll_results(org, since, until):
         .exclude(flow_uuid="")
         .distinct("flow_uuid")
     ):
-        if deadline is not None and time.time() > deadline:
-            logger.info("Time budget exhausted backfilling results for org #%d, will resume next cycle" % org.id)
+        if _sync_should_stop(deadline):
+            logger.info("Stopping backfilling results early for org #%d, will resume next cycle" % org.id)
             break
         (
             num_val_created,
@@ -112,8 +121,8 @@ def pull_results_other_polls(org, since, until):
     other_polls = Poll.objects.filter(id__in=other_polls_ids).order_by("-created_on")
     deadline = _sync_deadline()
     for poll in other_polls:
-        if deadline is not None and time.time() > deadline:
-            logger.info("Time budget exhausted pulling other polls for org #%d, will resume next cycle" % org.id)
+        if _sync_should_stop(deadline):
+            logger.info("Stopping pulling other polls early for org #%d, will resume next cycle" % org.id)
             break
         key = Poll.POLL_RESULTS_LAST_OTHER_POLLS_SYNCED_CACHE_KEY % (org.id, poll.flow_uuid)
         if not cache.get(key):
@@ -153,8 +162,8 @@ def pull_results_recent_polls(org, since, until):
     recent_polls = Poll.objects.filter(id__in=recent_polls_ids).order_by("-created_on")
     deadline = _sync_deadline()
     for poll in recent_polls:
-        if deadline is not None and time.time() > deadline:
-            logger.info("Time budget exhausted pulling recent polls for org #%d, will resume next cycle" % org.id)
+        if _sync_should_stop(deadline):
+            logger.info("Stopping pulling recent polls early for org #%d, will resume next cycle" % org.id)
             break
         (
             num_val_created,

--- a/ureport/polls/tests.py
+++ b/ureport/polls/tests.py
@@ -3252,6 +3252,25 @@ class PollsTasksTest(UreportTest):
         pull_results_recent_polls(self.nigeria.pk)
         self.assertFalse(mock_pull_results.called)
 
+    @patch("ureport.polls.tasks.is_sync_shutting_down")
+    @patch("ureport.polls.models.Poll.get_flow_date")
+    @patch("dash.orgs.models.Org.get_backend")
+    @patch("ureport.tests.TestBackend.pull_results")
+    def test_backfill_poll_results_worker_shutdown(
+        self, mock_pull_results, mock_get_backend, mock_get_flow_date, mock_shutting_down
+    ):
+        mock_get_backend.return_value = TestBackend(self.rapidpro_backend)
+        mock_pull_results.return_value = (1, 2, 3, 4, 5, 6)
+        mock_get_flow_date.return_value = None
+        mock_shutting_down.return_value = True
+
+        self.poll.has_synced = False
+        self.poll.save()
+
+        # a shutting down worker starts no new poll syncs, leaving them for the next cycle
+        backfill_poll_results(self.nigeria.pk)
+        self.assertFalse(mock_pull_results.called)
+
     @patch("ureport.polls.models.Poll.get_flow_date")
     @patch("dash.orgs.models.Org.get_backend")
     @patch("ureport.tests.TestBackend.pull_results")

--- a/ureport/sync_state.py
+++ b/ureport/sync_state.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+import logging
+import socket
+
+from django.core.cache import cache
+
+logger = logging.getLogger(__name__)
+
+# the flag is keyed by machine hostname because the worker main process receives the shutdown
+# signal while sync loops run in forked pool children - the cache is their shared channel
+SYNC_SHUTDOWN_CACHE_KEY = "sync_worker_shutdown:%s"
+
+# generously outlives any shutdown grace period while still self-clearing if the worker is
+# replaced by one with the same hostname that missed the startup cleanup
+SYNC_SHUTDOWN_CACHE_TIMEOUT = 60 * 10
+
+
+def signal_sync_shutdown():
+    """
+    Marks this host's worker as shutting down so sync loops pause at their next checkpoint
+    """
+    cache.set(SYNC_SHUTDOWN_CACHE_KEY % socket.gethostname(), True, SYNC_SHUTDOWN_CACHE_TIMEOUT)
+    logger.info("Flagged sync shutdown for host %s" % socket.gethostname())
+
+
+def clear_sync_shutdown():
+    """
+    Clears the shutdown flag, called when a worker starts on this host
+    """
+    cache.delete(SYNC_SHUTDOWN_CACHE_KEY % socket.gethostname())
+
+
+def is_sync_shutting_down():
+    """
+    Whether the worker on this host is shutting down and sync loops should pause
+    """
+    return bool(cache.get(SYNC_SHUTDOWN_CACHE_KEY % socket.gethostname()))

--- a/ureport/utils/tests.py
+++ b/ureport/utils/tests.py
@@ -71,6 +71,18 @@ class UtilsTest(UreportTest):
         self.assertEqual(json_date_to_datetime("2014-01-02T01:04:05.000Z"), d2)
         self.assertEqual(json_date_to_datetime("2014-01-02T01:04:05.000"), d2)
 
+    def test_sync_shutdown_flag(self):
+        from ureport.sync_state import clear_sync_shutdown, is_sync_shutting_down, signal_sync_shutdown
+
+        clear_sync_shutdown()
+        self.assertFalse(is_sync_shutting_down())
+
+        signal_sync_shutdown()
+        self.assertTrue(is_sync_shutting_down())
+
+        clear_sync_shutdown()
+        self.assertFalse(is_sync_shutting_down())
+
     def test_org_sync_lock_timeout(self):
         # without a time budget, tasks keep their long lock timeouts
         with override_settings(SYNC_TASK_TIME_BUDGET=None):


### PR DESCRIPTION
Part 3 of the sync-resilience stack, on top of #1370.

When a worker receives its termination signal, only the main process sees it — sync loops run in forked pool children, which are killed outright when the grace period ends. This wires the shutdown through so loops pause at a checkpoint first.

Changes:
- \`worker_shutting_down\` sets a host-keyed flag in the shared cache (new \`ureport/sync_state.py\`); \`worker_ready\` clears it on startup. The flag self-expires as a fallback.
- The poll results fetch loop checks the flag at each page boundary and takes the existing pause path (checkpoint, mark paused, requeue).
- The per-poll task loops (\`backfill_poll_results\`, \`pull_results_recent_polls\`, \`pull_results_other_polls\`) stop starting new polls when the flag is set.

Combined with the earlier parts of the stack, a stopped worker checkpoints everything within its grace period, and a hard kill only ever lands on already-persisted state.