### PR TITLE
Harden Celery config for containerized workers

### DIFF
--- a/ureport/polls/tasks.py
+++ b/ureport/polls/tasks.py
@@ -204,7 +204,9 @@ def clear_old_poll_results(org, since, until):
                     )
 
 
-@app.task()
+# acks late so an admin-triggered action interrupted by a worker stop is redelivered
+# rather than silently lost - there is no periodic trigger to retry it
+@app.task(acks_late=True, reject_on_worker_lost=True)
 def update_or_create_questions(poll_ids):
     from .models import Poll
 
@@ -219,7 +221,9 @@ def pull_refresh(poll_id):
     Poll.pull_results(poll_id)
 
 
-@app.task(name="polls.update_questions_results_cache")
+# acks late so an admin-triggered action interrupted by a worker stop is redelivered
+# rather than silently lost - there is no periodic trigger to retry it
+@app.task(name="polls.update_questions_results_cache", acks_late=True, reject_on_worker_lost=True)
 def update_questions_results_cache(poll_id):
     from .models import Poll
 

--- a/ureport/settings_common.py
+++ b/ureport/settings_common.py
@@ -907,15 +907,26 @@ ANONYMOUS_USER_NAME = "AnonymousUser"
 # Valkey Configuration
 # -----------------------------------------------------------------------------------
 
-# by default, celery doesn't have any timeout on our valkey connections, this fixes that
-BROKER_TRANSPORT_OPTIONS = {"socket_timeout": 5}
-
 CELERY_BROKER_URL = "redis://localhost:6379/1"
 
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 
-# by default, celery doesn't have any timeout on our valkey connections, this fixes that
-CELERY_BROKER_TRANSPORT_OPTIONS = {"socket_timeout": 5}
+# by default, celery doesn't have any timeout on our valkey connections, this fixes that.
+# visibility_timeout controls how long any unacknowledged message is hidden before the
+# broker redelivers it - that includes messages prefetched by a busy worker and
+# countdown/eta messages, not just acks_late tasks - so it must exceed the worst-case
+# task runtime and the longest countdown or the message is redelivered while still in
+# flight (the transport default is only an hour)
+CELERY_BROKER_TRANSPORT_OPTIONS = {"socket_timeout": 5, "visibility_timeout": 60 * 60 * 25}
+
+# fetch one task per worker process at a time so a stopping worker holds at most one
+# unstarted task, and long tasks don't strand queued work behind them
+CELERY_WORKER_PREFETCH_MULTIPLIER = 1
+
+# backstop limits for runaway tasks - generous enough for the longest legitimate syncs.
+# TODO: tighten per task as tasks are converted to bounded chunks
+CELERY_TASK_SOFT_TIME_LIMIT = 60 * 60 * 23
+CELERY_TASK_TIME_LIMIT = 60 * 60 * 24
 
 CELERY_TIMEZONE = "UTC"
 


### PR DESCRIPTION
First of three groundwork PRs toward making background tasks resumable and safe to run on container platforms that stop workers routinely (deploys, scale-in).

Configuration only, no task logic changes:

- Set the broker `visibility_timeout` (25h) above the worst-case task runtime. This applies to **all** unacknowledged messages — prefetched and countdown/eta messages included, not just `acks_late` tasks — and the transport default is only an hour, so long-running tasks were exposed to mid-run redelivery.
- `worker_prefetch_multiplier = 1` so a stopping worker holds at most one unstarted task per process and long tasks don't strand queued work behind them.
- Generous soft/hard time limits (23h/24h) as a backstop against runaway tasks, to be tightened per task as tasks are converted to bounded chunks.
- Remove the long-dead unprefixed `BROKER_TRANSPORT_OPTIONS` setting (not read under the `CELERY` settings namespace).

`acks_late` is deliberately **not** enabled globally: existing monolithic tasks are not idempotent under redelivery. It will be enabled per task as each task family is converted to the chunked framework (see the companion `sync-jobs-framework` PR).