### PR TITLE
Add chunk-aware backend pull methods

### DIFF
--- a/ureport/backend/__init__.py
+++ b/ureport/backend/__init__.py
@@ -1,6 +1,26 @@
 # -*- coding: utf-8 -*-
 
 from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass, field
+
+from dash.utils.sync import SyncOutcome
+
+
+@dataclass
+class ChunkResult:
+    """
+    The outcome of one bounded chunk of a pull. Both counts and cursor are JSON
+    serializable; the cursor is an opaque resume position that yields no missed data when
+    passed to the next chunk call (duplicate work is acceptable - writes are upserts);
+    done is True when the pull has no work left; rate_limited is True when the chunk
+    stopped early because the API rate limit was exhausted and the caller should back off
+    before the next chunk.
+    """
+
+    counts: dict = field(default_factory=dict)
+    cursor: dict = field(default_factory=dict)
+    done: bool = False
+    rate_limited: bool = False
 
 
 class BaseBackend(object):
@@ -38,3 +58,62 @@ class BaseBackend(object):
         :return: tuple of the number of contacts created, updated, deleted and ignored
         """
         pass
+
+    # ------------------------------------------------------------------------------
+    # Chunked pulls - bounded, resumable units of the pulls above. These defaults do
+    # the entire pull as a single chunk; backends that support real pagination should
+    # override them to do a bounded amount of work per call and return a cursor.
+    # ------------------------------------------------------------------------------
+
+    def pull_contacts_chunk(self, org, modified_after, modified_before, cursor, time_budget=None):
+        """
+        Pulls one bounded chunk of contacts modified in the given time window. The window
+        must stay fixed for the life of a cursor: a resumed page cursor is only valid
+        against the exact query it came from, so callers freeze (after, before) when a
+        traversal starts and roll the window only after done.
+        :param cursor: the resume position returned by the previous chunk, or {} to start
+        :return: a ChunkResult whose counts dict has the created/updated/deleted/ignored keys
+        """
+        counts, _ = self.pull_contacts(org, modified_after, modified_before)
+        return ChunkResult(counts=self._outcome_counts_dict(counts), cursor={}, done=True)
+
+    def pull_results_chunk(self, poll, cursor, page_budget=None):
+        """
+        Pulls one bounded chunk of results for the given poll.
+        :param cursor: the resume position returned by the previous chunk, or {} to start
+        :return: a ChunkResult whose counts dict has the num_val_* / num_path_* / num_synced keys
+        """
+        counts = self.pull_results(poll, None, None)
+        return ChunkResult(counts=self._results_counts_dict(counts), cursor=dict(cursor), done=True)
+
+    def pull_results_from_archives_chunk(self, poll, cursor, archive_budget=None):
+        """
+        Pulls one bounded chunk of archived results for the given poll. Backends without
+        archives complete immediately.
+        :param cursor: the resume position returned by the previous chunk, or {} to start
+        :return: a ChunkResult whose counts dict has the num_val_* / num_path_* / num_synced keys
+        """
+        return ChunkResult(counts=self._results_counts_dict(()), cursor=dict(cursor), done=True)
+
+    @staticmethod
+    def _results_counts_dict(counts_tuple):
+        keys = (
+            "num_val_created",
+            "num_val_updated",
+            "num_val_ignored",
+            "num_path_created",
+            "num_path_updated",
+            "num_path_ignored",
+            "num_synced",
+        )
+        counts = dict(zip(keys, counts_tuple))
+        return {key: counts.get(key, 0) for key in keys}
+
+    @staticmethod
+    def _outcome_counts_dict(outcome_counts):
+        return {
+            "created": outcome_counts.get(SyncOutcome.created, 0),
+            "updated": outcome_counts.get(SyncOutcome.updated, 0),
+            "deleted": outcome_counts.get(SyncOutcome.deleted, 0),
+            "ignored": outcome_counts.get(SyncOutcome.ignored, 0),
+        }

--- a/ureport/backend/rapidpro.py
+++ b/ureport/backend/rapidpro.py
@@ -27,7 +27,7 @@ from ureport.polls.tasks import pull_refresh_from_archives
 from ureport.stats.models import ContactActivity
 from ureport.utils import chunk_list, datetime_to_json_date, json_date_to_datetime
 
-from . import BaseBackend
+from . import BaseBackend, ChunkResult
 
 logger = logging.getLogger(__name__)
 
@@ -764,6 +764,311 @@ class RapidProBackend(BaseBackend):
             stats_dict["num_path_updated"],
             stats_dict["num_path_ignored"],
         )
+
+    # ------------------------------------------------------------------------------
+    # Chunked pulls - bounded, resumable units of the pulls above. Unlike the methods
+    # they mirror, these hold no locks and write no cache bookkeeping: the caller owns
+    # cursor persistence, scheduling of the next chunk, and count rebuilds.
+    # ------------------------------------------------------------------------------
+
+    RESULTS_PAGE_BUDGET = 20  # API pages of runs per chunk
+    CONTACTS_TIME_BUDGET = 60 * 2  # seconds of active contact syncing per chunk
+    CONTACTS_DELETED_PAGE_BUDGET = 25  # API pages of deleted contacts per chunk
+    ARCHIVES_BUDGET = 1  # archive files with records per chunk
+
+    def pull_results_chunk(self, poll, cursor, page_budget=None):
+        """
+        Pulls up to page_budget API pages of runs for the poll. The cursor's "after" key is
+        the durable incremental position (newest modified_on synced) and its "resume" key
+        is the API page cursor within the current traversal.
+        """
+        if page_budget is None:
+            page_budget = self.RESULTS_PAGE_BUDGET
+        org = poll.org
+
+        stats_dict = dict(
+            num_val_created=0,
+            num_val_updated=0,
+            num_val_ignored=0,
+            num_path_created=0,
+            num_path_updated=0,
+            num_path_ignored=0,
+            num_synced=0,
+        )
+
+        if poll.stopped_syncing:
+            return ChunkResult(counts=stats_dict, cursor=dict(cursor), done=True)
+
+        client = self._get_client(org, 2)
+        questions_uuids = poll.get_question_uuids()
+
+        latest_synced_obj_time = cursor.get("after")
+
+        poll_runs_query = client.get_runs(flow=poll.flow_uuid, after=latest_synced_obj_time, reverse=True, paths=True)
+        fetches = poll_runs_query.iterfetches(retry_on_rate_exceed=True, resume_cursor=cursor.get("resume"))
+
+        pages = 0
+        done = False
+        rate_limited = False
+
+        try:
+            for fetch in fetches:
+                (contacts_map, poll_results_map, poll_results_to_save_map) = self._initiate_lookup_maps(
+                    fetch, org, poll
+                )
+
+                for temba_run in fetch:
+                    if latest_synced_obj_time is None or temba_run.modified_on > json_date_to_datetime(
+                        latest_synced_obj_time
+                    ):
+                        latest_synced_obj_time = datetime_to_json_date(temba_run.modified_on.replace(tzinfo=tzone.utc))
+
+                    contact_obj = contacts_map.get(temba_run.contact.uuid, None)
+                    self._process_run_poll_results(
+                        org,
+                        questions_uuids,
+                        temba_run,
+                        contact_obj,
+                        poll_results_map,
+                        poll_results_to_save_map,
+                        stats_dict,
+                    )
+
+                stats_dict["num_synced"] += len(fetch)
+                self._save_new_poll_results_to_database(poll_results_to_save_map)
+
+                # release per-page lookup maps holding cyclic references before next allocation
+                del contacts_map, poll_results_map, poll_results_to_save_map
+                gc.collect()
+
+                pages += 1
+                if pages >= page_budget:
+                    break
+            else:
+                done = True
+        except TembaRateExceededError:
+            rate_limited = True
+
+        next_cursor = {"after": latest_synced_obj_time}
+        if not done:
+            page_cursor = fetches.get_cursor()
+            if rate_limited:
+                # the iterator has no cursor until a fetch succeeds, so a rate limit on the
+                # first page of a resumed chunk must fall back to the incoming position
+                page_cursor = page_cursor or cursor.get("resume")
+            if page_cursor:
+                next_cursor["resume"] = page_cursor
+            elif not rate_limited:
+                # budget was hit on the traversal's last page - there is nothing left
+                done = True
+
+        return ChunkResult(counts=stats_dict, cursor=next_cursor, done=done, rate_limited=rate_limited)
+
+    def pull_contacts_chunk(self, org, modified_after, modified_before, cursor, time_budget=None):
+        """
+        Pulls one bounded chunk of contacts modified in the given time window. The pull
+        moves through two stages recorded in the cursor: "active" (changed contacts, time
+        boxed) then "deleted" (removed contacts, page bounded), each resumable from a page
+        cursor. The window must stay fixed for the life of the cursor: a resumed page
+        cursor is only valid against the exact query it came from, so callers freeze
+        (modified_after, modified_before) when a traversal starts and roll the window only
+        after done.
+        """
+        if time_budget is None:
+            time_budget = self.CONTACTS_TIME_BUDGET
+        client = self._get_client(org, 2)
+        syncer = ContactSyncer(backend=self.backend)
+
+        stage = cursor.get("stage", "active")
+
+        if stage == "active":
+            active_query = client.get_contacts(after=modified_after, before=modified_before)
+            fetches = active_query.iterfetches(retry_on_rate_exceed=True, resume_cursor=cursor.get("resume"))
+
+            try:
+                outcome_counts, resume_cursor = sync_local_to_changes(org, syncer, fetches, [], time_limit=time_budget)
+            except TembaRateExceededError:
+                # objects synced before the limit hit are already saved, only their counts
+                # are lost; the iterator has no cursor until a fetch succeeds so fall back
+                # to the incoming position
+                next_cursor = {"stage": "active"}
+                page_cursor = fetches.get_cursor() or cursor.get("resume")
+                if page_cursor:
+                    next_cursor["resume"] = page_cursor
+                return ChunkResult(counts=self._outcome_counts_dict({}), cursor=next_cursor, rate_limited=True)
+
+            counts = self._outcome_counts_dict(outcome_counts)
+            if resume_cursor:
+                return ChunkResult(counts=counts, cursor={"stage": "active", "resume": resume_cursor}, done=False)
+            return ChunkResult(counts=counts, cursor={"stage": "deleted"}, done=False)
+
+        # deleted stage - page bounded so a bulk contact purge can't run unbounded
+        deleted_query = client.get_contacts(deleted=True, after=modified_after, before=modified_before)
+        deleted_fetches = deleted_query.iterfetches(retry_on_rate_exceed=True, resume_cursor=cursor.get("resume"))
+
+        counts = self._outcome_counts_dict({})
+        pages = 0
+        done = False
+
+        try:
+            for fetch in deleted_fetches:
+                for deleted_remote in fetch:
+                    identity = syncer.identify_remote(deleted_remote)
+                    with syncer.lock(org, identity):
+                        existing = syncer.fetch_local(org, identity)
+                        if existing:
+                            syncer.delete_local(existing)
+                            counts["deleted"] += 1
+
+                pages += 1
+                if pages >= self.CONTACTS_DELETED_PAGE_BUDGET:
+                    break
+            else:
+                done = True
+        except TembaRateExceededError:
+            next_cursor = {"stage": "deleted"}
+            page_cursor = deleted_fetches.get_cursor() or cursor.get("resume")
+            if page_cursor:
+                next_cursor["resume"] = page_cursor
+            return ChunkResult(counts=counts, cursor=next_cursor, rate_limited=True)
+
+        if done:
+            return ChunkResult(counts=counts, cursor={}, done=True)
+
+        next_cursor = {"stage": "deleted"}
+        page_cursor = deleted_fetches.get_cursor()
+        if page_cursor:
+            next_cursor["resume"] = page_cursor
+        else:
+            # budget was hit on the traversal's last page - there is nothing left
+            return ChunkResult(counts=counts, cursor={}, done=True)
+        return ChunkResult(counts=counts, cursor=next_cursor, done=False)
+
+    def pull_results_from_archives_chunk(self, poll, cursor, archive_budget=None):
+        """
+        Pulls archived results for the poll, processing up to archive_budget archive files
+        with records per chunk. Archives are listed newest first (by start_date, with
+        rolled-up dailies excluded), and the cursor is content addressed so the traversal
+        survives the listing changing between chunks (new archives appearing, dailies
+        rolling up into monthlies): "before" is the start_date of the last archive visited
+        and "seen" the period keys already processed at that exact date - together they
+        say "resume strictly below this position". Archives newer than "before" are
+        outside this traversal; their runs were still in the live API when the traversal
+        started. Archives that fail to process are recorded under "failed" and skipped.
+        """
+        if archive_budget is None:
+            archive_budget = self.ARCHIVES_BUDGET
+        org = poll.org
+
+        stats_dict = dict(
+            num_val_created=0,
+            num_val_updated=0,
+            num_val_ignored=0,
+            num_path_created=0,
+            num_path_updated=0,
+            num_path_ignored=0,
+            num_synced=0,
+        )
+
+        if poll.stopped_syncing:
+            return ChunkResult(counts=stats_dict, cursor=dict(cursor), done=True)
+
+        flow_date_json = poll.get_flow_date()
+        first = (
+            json_date_to_datetime(flow_date_json).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+            if flow_date_json
+            else None
+        )
+
+        client = self._get_client(org, 2)
+        questions_uuids = poll.get_question_uuids()
+
+        before = cursor.get("before")
+        seen = set(cursor.get("seen") or [])
+        failed = list(cursor.get("failed") or [])
+
+        # before filters start_date inclusively server-side, so archives at the boundary
+        # date reappear and are dropped by the seen set below
+        archives_query = client.get_archives(type="run", after=first, before=before)
+        archives_fetches = archives_query.iterfetches(retry_on_rate_exceed=True)
+
+        processed = 0
+        more = False
+        rate_limited = False
+
+        try:
+            for archives in archives_fetches:
+                for archive in archives:
+                    # YYYY-MM-DD, so lexicographic comparison is chronological
+                    start_iso = str(archive.start_date)[:10]
+                    key = f"{start_iso}|{archive.period}"
+
+                    if before is not None:
+                        if start_iso > before:
+                            # appeared after this traversal started - its runs were still
+                            # in the live API then, so the API pull covers them
+                            continue
+                        if start_iso == before and key in seen:
+                            continue
+
+                    if processed >= archive_budget:
+                        more = True
+                        break
+
+                    logger.info("Archive %s with %d records, size %d" % (key, archive.record_count, archive.size))
+
+                    try:
+                        if archive.record_count > 0:
+                            start_archive = time.time()
+
+                            for fetch in self._iter_poll_record_runs(archive, poll.flow_uuid):
+                                (contacts_map, poll_results_map, poll_results_to_save_map) = self._initiate_lookup_maps(
+                                    fetch, org, poll
+                                )
+
+                                for temba_run in fetch:
+                                    contact_obj = contacts_map.get(temba_run.contact.uuid, None)
+                                    self._process_run_poll_results(
+                                        org,
+                                        questions_uuids,
+                                        temba_run,
+                                        contact_obj,
+                                        poll_results_map,
+                                        poll_results_to_save_map,
+                                        stats_dict,
+                                    )
+
+                                stats_dict["num_synced"] += len(fetch)
+                                self._save_new_poll_results_to_database(poll_results_to_save_map)
+
+                                # release per-page lookup maps holding cyclic references before next allocation
+                                del contacts_map, poll_results_map, poll_results_to_save_map
+                                gc.collect()
+
+                            logger.info("Full poll process archive in %ds" % (time.time() - start_archive))
+                            processed += 1
+                    except Exception as e:
+                        # advance past the broken archive but keep its key so the caller can
+                        # see the traversal was not clean
+                        failed.append(key)
+                        processed += 1
+                        logger.error("Error processing archive %s for poll #%d" % (key, poll.pk), exc_info=e)
+
+                    if start_iso == before:
+                        seen.add(key)
+                    else:
+                        before = start_iso
+                        seen = {key}
+                if more:
+                    break
+        except TembaRateExceededError:
+            rate_limited = True
+
+        done = not more and not rate_limited
+        next_cursor = {"before": before, "seen": sorted(seen)}
+        if failed:
+            next_cursor["failed"] = failed
+        return ChunkResult(counts=stats_dict, cursor=next_cursor, done=done, rate_limited=rate_limited)
 
     def _initiate_lookup_maps(self, fetch, org, poll):
         """

--- a/ureport/backend/tests/test_chunks.py
+++ b/ureport/backend/tests/test_chunks.py
@@ -1,0 +1,493 @@
+# -*- coding: utf-8 -*-
+
+import json
+
+from mock import patch
+from temba_client.exceptions import TembaRateExceededError
+from temba_client.v2.types import Archive as TembaArchive, Contact as TembaContact, ObjectRef, Run as TembaRun
+
+from django.utils import timezone
+
+from dash.categories.models import Category
+from ureport.backend import BaseBackend, ChunkResult
+from ureport.backend.rapidpro import RapidProBackend
+from ureport.contacts.models import Contact
+from ureport.polls.models import PollResult
+from ureport.tests import UreportTest
+from ureport.utils import datetime_to_json_date
+
+
+class CursorMockIterator:
+    def __init__(self, fetches, pos, raise_on_fetch):
+        self.fetches = fetches
+        self.pos = pos
+        self.raise_on_fetch = raise_on_fetch
+        self.fetched_any = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.raise_on_fetch is not None and self.pos == self.raise_on_fetch:
+            raise TembaRateExceededError(0)
+        if self.pos >= len(self.fetches):
+            raise StopIteration()
+        fetch = self.fetches[self.pos]
+        self.pos += 1
+        self.fetched_any = True
+        return fetch
+
+    def get_cursor(self):
+        # like the real client: no cursor until a fetch has succeeded on THIS iterator
+        # (a pending resume_cursor is not consulted), and none once exhausted
+        if not self.fetched_any:
+            return None
+        return str(self.pos) if self.pos < len(self.fetches) else None
+
+
+class CursorMockQuery:
+    """
+    Like dash's MockClientQuery but honoring iterfetches' resume_cursor and exposing
+    get_cursor with the real client's semantics, so chunked pulls can be tested for
+    resume behavior.
+    """
+
+    def __init__(self, *fetches, raise_on_fetch=None):
+        self.fetches = list(fetches)
+        self.raise_on_fetch = raise_on_fetch
+
+    def iterfetches(self, retry_on_rate_exceed=False, resume_cursor=None):
+        return CursorMockIterator(self.fetches, int(resume_cursor) if resume_cursor else 0, self.raise_on_fetch)
+
+
+class PullResultsChunkTest(UreportTest):
+    def setUp(self):
+        super().setUp()
+        self.backend = RapidProBackend(self.rapidpro_backend)
+        education = Category.objects.create(
+            org=self.nigeria, name="Education", created_by=self.admin, modified_by=self.admin
+        )
+        self.poll = self.create_poll(self.nigeria, "Flow 1", "flow-uuid", education, self.admin)
+        self.create_poll_question(self.admin, self.poll, "question 1", "ruleset-uuid")
+
+        PollResult.objects.all().delete()
+        Contact.objects.create(org=self.nigeria, uuid="C-001", gender="M", born=1990)
+        Contact.objects.create(org=self.nigeria, uuid="C-002", gender="F", born=1995)
+
+    def _run(self, uuid, contact_uuid, value, modified_on):
+        return TembaRun.create(
+            uuid=uuid,
+            flow=ObjectRef.create(uuid="flow-uuid", name="Flow 1"),
+            contact=ObjectRef.create(uuid=contact_uuid, name="Reporter"),
+            responded=True,
+            values={"q1": TembaRun.Value.create(value=value, category="Win", node="ruleset-uuid", time=modified_on)},
+            path=[TembaRun.Step.create(node="ruleset-uuid", time=modified_on)],
+            created_on=modified_on,
+            modified_on=modified_on,
+            exited_on=modified_on,
+            exit_type="completed",
+        )
+
+    @patch("dash.orgs.models.TembaClient.get_runs")
+    def test_completes_in_one_chunk(self, mock_get_runs):
+        now = timezone.now()
+        run1 = self._run(1234, "C-001", "yes", now - timezone.timedelta(hours=1))
+        run2 = self._run(1235, "C-002", "no", now)
+        mock_get_runs.return_value = CursorMockQuery([run1], [run2])
+
+        result = self.backend.pull_results_chunk(self.poll, {})
+
+        self.assertTrue(result.done)
+        self.assertFalse(result.rate_limited)
+        self.assertEqual(result.counts["num_val_created"], 2)
+        self.assertEqual(result.counts["num_synced"], 2)
+        self.assertEqual(result.cursor["after"], datetime_to_json_date(now))
+        self.assertNotIn("resume", result.cursor)
+        self.assertEqual(PollResult.objects.filter(flow="flow-uuid").count(), 2)
+
+        # the chunk contract: counts and cursor are JSON serializable
+        json.dumps(result.counts)
+        json.dumps(result.cursor)
+
+        mock_get_runs.assert_called_with(flow="flow-uuid", after=None, reverse=True, paths=True)
+
+    @patch("dash.orgs.models.TembaClient.get_runs")
+    def test_empty_first_page(self, mock_get_runs):
+        mock_get_runs.return_value = CursorMockQuery()
+
+        result = self.backend.pull_results_chunk(self.poll, {})
+
+        self.assertTrue(result.done)
+        self.assertEqual(result.cursor, {"after": None})
+        json.dumps(result.cursor)
+
+    @patch("dash.orgs.models.TembaClient.get_runs")
+    def test_resumes_across_chunks(self, mock_get_runs):
+        now = timezone.now()
+        earlier = now - timezone.timedelta(hours=1)
+        run1 = self._run(1234, "C-001", "yes", earlier)
+        run2 = self._run(1235, "C-002", "no", now)
+        mock_get_runs.return_value = CursorMockQuery([run1], [run2])
+
+        first = self.backend.pull_results_chunk(self.poll, {}, page_budget=1)
+
+        self.assertFalse(first.done)
+        self.assertEqual(first.counts["num_val_created"], 1)
+        self.assertEqual(first.cursor, {"after": datetime_to_json_date(earlier), "resume": "1"})
+        self.assertEqual(PollResult.objects.filter(flow="flow-uuid").count(), 1)
+
+        second = self.backend.pull_results_chunk(self.poll, first.cursor, page_budget=1)
+
+        self.assertTrue(second.done)
+        self.assertEqual(second.counts["num_val_created"], 1)
+        self.assertEqual(second.cursor["after"], datetime_to_json_date(now))
+        self.assertEqual(PollResult.objects.filter(flow="flow-uuid").count(), 2)
+
+        # both chunks together produced exactly what one pass would have
+        self.assertEqual(
+            set(PollResult.objects.filter(flow="flow-uuid").values_list("contact", flat=True)), {"C-001", "C-002"}
+        )
+
+    @patch("dash.orgs.models.TembaClient.get_runs")
+    def test_budget_ending_on_last_page_is_done(self, mock_get_runs):
+        now = timezone.now()
+        mock_get_runs.return_value = CursorMockQuery([self._run(1234, "C-001", "yes", now)])
+
+        result = self.backend.pull_results_chunk(self.poll, {}, page_budget=1)
+
+        self.assertTrue(result.done)
+        self.assertNotIn("resume", result.cursor)
+
+    @patch("dash.orgs.models.TembaClient.get_runs")
+    def test_rate_limit_keeps_progress(self, mock_get_runs):
+        now = timezone.now()
+        earlier = now - timezone.timedelta(hours=1)
+        run1 = self._run(1234, "C-001", "yes", earlier)
+        run2 = self._run(1235, "C-002", "no", now)
+        mock_get_runs.return_value = CursorMockQuery([run1], [run2], raise_on_fetch=1)
+
+        result = self.backend.pull_results_chunk(self.poll, {})
+
+        self.assertFalse(result.done)
+        self.assertTrue(result.rate_limited)
+        # the first page's work is kept and the cursor resumes at the failed page
+        self.assertEqual(result.counts["num_val_created"], 1)
+        self.assertEqual(result.cursor, {"after": datetime_to_json_date(earlier), "resume": "1"})
+
+    @patch("dash.orgs.models.TembaClient.get_runs")
+    def test_rate_limit_on_first_page_of_resumed_chunk_keeps_resume_cursor(self, mock_get_runs):
+        now = timezone.now()
+        run1 = self._run(1234, "C-001", "yes", now)
+        run2 = self._run(1235, "C-002", "no", now)
+        # resumed at page 1, which immediately rate limits - no fetch succeeds
+        mock_get_runs.return_value = CursorMockQuery([run1], [run2], raise_on_fetch=1)
+
+        cursor = {"after": datetime_to_json_date(now), "resume": "1"}
+        result = self.backend.pull_results_chunk(self.poll, cursor)
+
+        self.assertTrue(result.rate_limited)
+        # the incoming resume position must survive, not be dropped
+        self.assertEqual(result.cursor["resume"], "1")
+
+    @patch("dash.orgs.models.TembaClient.get_runs")
+    def test_stopped_syncing_poll_is_done_immediately(self, mock_get_runs):
+        self.poll.stopped_syncing = True
+        self.poll.save()
+
+        result = self.backend.pull_results_chunk(self.poll, {"after": "t1"})
+
+        self.assertTrue(result.done)
+        self.assertEqual(result.cursor, {"after": "t1"})
+        mock_get_runs.assert_not_called()
+
+
+class PullContactsChunkTest(UreportTest):
+    def setUp(self):
+        super().setUp()
+        self.backend = RapidProBackend(self.rapidpro_backend)
+
+    def _contact(self, uuid):
+        # not in the configured reporter group so it syncs with the ignored outcome
+        return TembaContact.create(
+            uuid=uuid,
+            name="Jan",
+            urns=[],
+            groups=[ObjectRef.create(uuid="G-007", name="Actors")],
+            fields={},
+            language="eng",
+            created_on=timezone.now(),
+        )
+
+    @patch("dash.orgs.models.TembaClient.get_contacts")
+    def test_active_stage_time_boxed_then_deleted_stage(self, mock_get_contacts):
+        mock_get_contacts.return_value = CursorMockQuery([self._contact("C-001")], [self._contact("C-002")])
+
+        # a tiny time budget stops the active stage after the first fetch
+        first = self.backend.pull_contacts_chunk(self.nigeria, None, None, {}, time_budget=0.000001)
+
+        self.assertFalse(first.done)
+        self.assertEqual(first.cursor, {"stage": "active", "resume": "1"})
+        self.assertEqual(first.counts["ignored"], 1)
+        json.dumps(first.counts)
+        json.dumps(first.cursor)
+
+        # resuming processes only the remaining fetch then moves to the deleted stage
+        second = self.backend.pull_contacts_chunk(self.nigeria, None, None, first.cursor, time_budget=600)
+
+        self.assertFalse(second.done)
+        self.assertEqual(second.cursor, {"stage": "deleted"})
+        self.assertEqual(second.counts["ignored"], 1)
+
+        # deleted stage completes the pull (no local contacts to delete)
+        mock_get_contacts.return_value = CursorMockQuery([self._contact("C-003")])
+        third = self.backend.pull_contacts_chunk(self.nigeria, None, None, second.cursor)
+
+        self.assertTrue(third.done)
+        self.assertEqual(third.cursor, {})
+        mock_get_contacts.assert_called_with(deleted=True, after=None, before=None)
+
+    @patch("dash.orgs.models.TembaClient.get_contacts")
+    def test_deleted_stage_is_page_bounded(self, mock_get_contacts):
+        pages = [[self._contact(f"C-{i:03}")] for i in range(RapidProBackend.CONTACTS_DELETED_PAGE_BUDGET + 2)]
+        mock_get_contacts.return_value = CursorMockQuery(*pages)
+
+        result = self.backend.pull_contacts_chunk(self.nigeria, None, None, {"stage": "deleted"})
+
+        self.assertFalse(result.done)
+        self.assertEqual(
+            result.cursor, {"stage": "deleted", "resume": str(RapidProBackend.CONTACTS_DELETED_PAGE_BUDGET)}
+        )
+
+        # resuming finishes the remaining pages
+        second = self.backend.pull_contacts_chunk(self.nigeria, None, None, result.cursor)
+        self.assertTrue(second.done)
+        self.assertEqual(second.cursor, {})
+
+    @patch("dash.orgs.models.TembaClient.get_contacts")
+    def test_rate_limit_returns_resume_cursor(self, mock_get_contacts):
+        mock_get_contacts.return_value = CursorMockQuery(
+            [self._contact("C-001")], [self._contact("C-002")], raise_on_fetch=1
+        )
+
+        result = self.backend.pull_contacts_chunk(self.nigeria, None, None, {})
+
+        self.assertFalse(result.done)
+        self.assertTrue(result.rate_limited)
+        self.assertEqual(result.cursor, {"stage": "active", "resume": "1"})
+
+    @patch("dash.orgs.models.TembaClient.get_contacts")
+    def test_rate_limit_on_first_page_of_resumed_chunk_keeps_resume_cursor(self, mock_get_contacts):
+        # resumed at page 1, which immediately rate limits - no fetch succeeds, so the
+        # iterator has no cursor and the incoming one must be kept
+        mock_get_contacts.return_value = CursorMockQuery(
+            [self._contact("C-001")], [self._contact("C-002")], raise_on_fetch=1
+        )
+
+        result = self.backend.pull_contacts_chunk(self.nigeria, None, None, {"stage": "active", "resume": "1"})
+
+        self.assertTrue(result.rate_limited)
+        self.assertEqual(result.cursor, {"stage": "active", "resume": "1"})
+
+
+class PullArchivesChunkTest(UreportTest):
+    def setUp(self):
+        super().setUp()
+        self.backend = RapidProBackend(self.rapidpro_backend)
+        education = Category.objects.create(
+            org=self.nigeria, name="Education", created_by=self.admin, modified_by=self.admin
+        )
+        self.poll = self.create_poll(self.nigeria, "Flow 1", "flow-uuid", education, self.admin)
+        self.create_poll_question(self.admin, self.poll, "question 1", "ruleset-uuid")
+
+        PollResult.objects.all().delete()
+        Contact.objects.create(org=self.nigeria, uuid="C-001", gender="M", born=1990)
+        Contact.objects.create(org=self.nigeria, uuid="C-002", gender="F", born=1995)
+
+    def _archive(self, start_date, record_count=1, period="daily"):
+        return TembaArchive.create(
+            type="run",
+            start_date=f"{start_date}T00:00:00.000Z",
+            period=period,
+            record_count=record_count,
+            size=1024,
+            hash="feca9988b7772c003204a28bd741d0d0",
+            download_url="http://example.com/archive.jsonl.gz",
+        )
+
+    def _key(self, archive):
+        return f"{str(archive.start_date)[:10]}|{archive.period}"
+
+    def _run(self, uuid, contact_uuid, modified_on):
+        return TembaRun.create(
+            uuid=uuid,
+            flow=ObjectRef.create(uuid="flow-uuid", name="Flow 1"),
+            contact=ObjectRef.create(uuid=contact_uuid, name="Reporter"),
+            responded=True,
+            values={"q1": TembaRun.Value.create(value="yes", category="Win", node="ruleset-uuid", time=modified_on)},
+            path=[TembaRun.Step.create(node="ruleset-uuid", time=modified_on)],
+            created_on=modified_on,
+            modified_on=modified_on,
+            exited_on=modified_on,
+            exit_type="completed",
+        )
+
+    @patch("ureport.backend.rapidpro.RapidProBackend._iter_poll_record_runs")
+    @patch("dash.orgs.models.TembaClient.get_archives")
+    def test_one_archive_per_chunk(self, mock_get_archives, mock_iter_records):
+        now = timezone.now()
+        newer, older = self._archive("2026-03-03"), self._archive("2026-03-02")
+        mock_get_archives.return_value = CursorMockQuery([newer, older])
+        mock_iter_records.side_effect = [
+            iter([[self._run(1234, "C-001", now)]]),
+            iter([[self._run(1235, "C-002", now)]]),
+        ]
+
+        first = self.backend.pull_results_from_archives_chunk(self.poll, {}, archive_budget=1)
+
+        self.assertFalse(first.done)
+        self.assertEqual(first.cursor, {"before": self._key(newer).split("|")[0], "seen": [self._key(newer)]})
+        self.assertEqual(first.counts["num_val_created"], 1)
+        self.assertEqual(PollResult.objects.filter(flow="flow-uuid").count(), 1)
+        json.dumps(first.cursor)
+
+        mock_get_archives.return_value = CursorMockQuery([newer, older])
+        second = self.backend.pull_results_from_archives_chunk(self.poll, first.cursor, archive_budget=1)
+
+        self.assertTrue(second.done)
+        self.assertEqual(second.cursor, {"before": self._key(older).split("|")[0], "seen": [self._key(older)]})
+        self.assertEqual(second.counts["num_val_created"], 1)
+        self.assertEqual(PollResult.objects.filter(flow="flow-uuid").count(), 2)
+
+        # only the unvisited archive was downloaded on the second chunk
+        self.assertEqual(mock_iter_records.call_count, 2)
+
+    @patch("ureport.backend.rapidpro.RapidProBackend._iter_poll_record_runs")
+    @patch("dash.orgs.models.TembaClient.get_archives")
+    def test_survives_listing_changing_between_chunks(self, mock_get_archives, mock_iter_records):
+        now = timezone.now()
+        processed_dates = []
+
+        def record(archive, flow_uuid):
+            processed_dates.append(str(archive.start_date)[:10])
+            return iter([[self._run(1000 + len(processed_dates), "C-001", now)]])
+
+        mock_iter_records.side_effect = record
+
+        # chunk 1 processes the newest daily
+        mock_get_archives.return_value = CursorMockQuery([self._archive("2026-02-03"), self._archive("2026-02-02")])
+        first = self.backend.pull_results_from_archives_chunk(self.poll, {}, archive_budget=1)
+        self.assertFalse(first.done)
+
+        # before chunk 2: a NEW newer archive appears and the Feb dailies roll up into a
+        # monthly - the listing has completely changed shape
+        mock_get_archives.return_value = CursorMockQuery(
+            [
+                self._archive("2026-02-04"),  # new, outside this traversal
+                self._archive("2026-02-01", period="monthly"),
+                self._archive("2026-01-15"),
+            ]
+        )
+        second = self.backend.pull_results_from_archives_chunk(self.poll, first.cursor, archive_budget=1)
+        self.assertFalse(second.done)
+
+        mock_get_archives.return_value = CursorMockQuery(
+            [
+                self._archive("2026-02-04"),
+                self._archive("2026-02-01", period="monthly"),
+                self._archive("2026-01-15"),
+            ]
+        )
+        third = self.backend.pull_results_from_archives_chunk(self.poll, second.cursor, archive_budget=1)
+        self.assertTrue(third.done)
+
+        # the new head archive was skipped (its runs were live when the traversal started),
+        # and the monthly rollup and older archive were both processed - nothing lost
+        self.assertEqual(processed_dates, ["2026-02-03", "2026-02-01", "2026-01-15"])
+
+    @patch("ureport.backend.rapidpro.RapidProBackend._iter_poll_record_runs")
+    @patch("dash.orgs.models.TembaClient.get_archives")
+    def test_empty_archives_do_not_consume_budget(self, mock_get_archives, mock_iter_records):
+        now = timezone.now()
+        mock_get_archives.return_value = CursorMockQuery(
+            [self._archive("2026-03-03", record_count=0), self._archive("2026-03-02", record_count=0)]
+        )
+
+        first = self.backend.pull_results_from_archives_chunk(self.poll, {}, archive_budget=1)
+
+        # both empties were passed in a single chunk without consuming the budget
+        self.assertTrue(first.done)
+        self.assertEqual(first.cursor["before"], "2026-03-02")
+        mock_iter_records.assert_not_called()
+
+        # a run-bearing archive after empties is still processed within the same chunk
+        mock_get_archives.return_value = CursorMockQuery(
+            [self._archive("2026-03-05", record_count=0), self._archive("2026-03-04", record_count=1)]
+        )
+        mock_iter_records.side_effect = [iter([[self._run(1234, "C-001", now)]])]
+        result = self.backend.pull_results_from_archives_chunk(self.poll, {}, archive_budget=1)
+        self.assertTrue(result.done)
+        self.assertEqual(result.counts["num_val_created"], 1)
+
+    @patch("dash.orgs.models.TembaClient.get_archives")
+    def test_failing_archive_is_recorded_and_does_not_block_progress(self, mock_get_archives):
+        broken = self._archive("2026-03-03")
+        mock_get_archives.return_value = CursorMockQuery([broken])
+
+        with patch.object(RapidProBackend, "_iter_poll_record_runs", side_effect=ValueError("corrupt")):
+            result = self.backend.pull_results_from_archives_chunk(self.poll, {}, archive_budget=1)
+
+        self.assertTrue(result.done)
+        self.assertEqual(result.cursor["failed"], [self._key(broken)])
+        self.assertEqual(result.counts["num_val_created"], 0)
+        json.dumps(result.cursor)
+
+
+class DummyBackend(BaseBackend):
+    def pull_fields(self, org):
+        return {}
+
+    def pull_boundaries(self, org):
+        return {}
+
+    def pull_contacts(self, org, modified_after, modified_before, progress_callback=None):
+        from dash.utils.sync import SyncOutcome
+
+        return ({SyncOutcome.created: 3, SyncOutcome.updated: 1}, None)
+
+    def pull_results(self, poll, modified_after, modified_before):
+        return (1, 2, 3, 4, 5, 6)
+
+
+class BaseBackendChunkDefaultsTest(UreportTest):
+    """
+    Backends without real pagination support (e.g. FLOIP) inherit single chunk defaults
+    so callers can use the chunked interface uniformly, with the same counts schema as
+    the chunked implementations.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.backend = DummyBackend(self.floip_backend)
+
+    def test_pull_contacts_chunk_default(self):
+        result = self.backend.pull_contacts_chunk(self.nigeria, None, None, {})
+
+        self.assertIsInstance(result, ChunkResult)
+        self.assertTrue(result.done)
+        self.assertEqual(result.counts, {"created": 3, "updated": 1, "deleted": 0, "ignored": 0})
+        json.dumps(result.counts)
+
+    def test_pull_results_chunk_default(self):
+        result = self.backend.pull_results_chunk(None, {})
+
+        self.assertTrue(result.done)
+        self.assertEqual(result.counts["num_val_created"], 1)
+        self.assertEqual(result.counts["num_path_ignored"], 6)
+        self.assertEqual(result.counts["num_synced"], 0)
+
+    def test_pull_archives_chunk_default(self):
+        result = self.backend.pull_results_from_archives_chunk(None, {"before": "t"})
+
+        self.assertTrue(result.done)
+        self.assertEqual(result.cursor, {"before": "t"})
+        self.assertEqual(result.counts["num_synced"], 0)


### PR DESCRIPTION
Third of three groundwork PRs toward making background tasks resumable. Adds cursor-in/cursor-out chunk variants of the backend pull methods; the existing pull methods are unchanged and current tasks keep working as before. Follow-up PRs will convert the tasks to drive these via the `syncjobs` framework and then delete the old pull paths.

Each chunk method does a bounded amount of work per call and returns a `ChunkResult` with JSON-serializable counts and cursor, a `done` flag, and a `rate_limited` flag so callers can back off without losing progress. The methods hold no locks and write no cache bookkeeping — the caller owns cursor persistence and scheduling of the next chunk.

- **`pull_results_chunk`** — up to N API pages of runs per call; the cursor carries the durable incremental position (newest `modified_on` synced) plus the API page cursor for resuming mid-traversal.
- **`pull_contacts_chunk`** — staged: a time-boxed active-contacts stage, then a page-bounded deleted-contacts stage, each resumable from a page cursor. The (after, before) window must stay frozen for the life of a cursor (documented).
- **`pull_results_from_archives_chunk`** — up to N archive files with records per call. The cursor is content-addressed on `start_date` rather than positional, so the traversal survives the archive listing changing between chunks (new archives appearing, dailies rolling up into monthlies); archives that fail to process are recorded in the cursor instead of silently dropped.

A rate limit that hits before any page succeeds falls back to the incoming resume position rather than dropping it (the API client's iterator has no cursor until a fetch succeeds).

The base backend provides single-chunk defaults with the same counts schema so backends without real pagination (e.g. FLOIP) support the same interface. 18 new tests cover resume equivalence with a single pass, budget boundaries, rate-limit recovery including the first-page-of-resumed-chunk case, listing drift, and empty/failing archives.