### PR TITLE
Convert the contacts maintenance tasks to chunked resumable sync jobs

### DIFF
--- a/ureport/contacts/maintenance.py
+++ b/ureport/contacts/maintenance.py
@@ -1,0 +1,351 @@
+# -*- coding: utf-8 -*-
+
+import logging
+from collections import defaultdict, namedtuple
+
+from django.core.cache import cache
+from django.utils import timezone
+
+from dash.orgs.models import Org
+from ureport.contacts.models import Contact
+from ureport.contacts.sync import (
+    JOB_TYPE as PULL_JOB_TYPE,
+    LOCK_BACKOFF,
+    contact_pull_lock,
+    enqueue_org_syncs,
+    force_full_repull,
+    is_pull_disabled,
+)
+from ureport.stats.models import ContactActivity
+from ureport.syncjobs.dispatch import enqueue, in_flight
+from ureport.syncjobs.models import SyncJob
+from ureport.syncjobs.tasks import chunked_task
+from ureport.utils import chunk_list, datetime_to_json_date, json_date_to_datetime
+
+logger = logging.getLogger(__name__)
+
+REBUILD_JOB_TYPE = "reporters-rebuild"
+ACTIVITIES_JOB_TYPE = "schemes-activities"
+RESULTS_JOB_TYPE = "schemes-results"
+
+QUEUE = "slow"
+
+# these chunks read or replace every contact of an org, so like the contact sync they need a
+# lease that comfortably exceeds the slowest of them
+LEASE_SECONDS = 60 * 30
+
+# the rebuild's lock has to outlive its lease: they would otherwise expire together, freeing
+# a second worker to claim the job at the moment the lock stops keeping it out - and two
+# concurrent rebuilds of the same counters leave them permanently wrong
+REBUILD_LOCK_TIMEOUT = LEASE_SECONDS * 2
+
+# the batch the pre-chunking backfills walked contacts in, and how many of them one chunk
+# takes on before handing back to the queue
+BATCH_SIZE = 1000
+BATCHES_PER_CHUNK = 5
+
+# set by the schemes backfill trigger while it waits for the full re-pull it asked for, and
+# read by the contact sync's finalization - the value is when the wait started. Given a TTL
+# so that a wait nothing can ever satisfy, e.g. an org whose last backend is deactivated
+# while it waits, expires instead of blocking the backfill forever. Scaffolding for the one
+# off backfill - remove it with the shims
+PENDING_KEY = "schemes_backfill_pending:%d"
+PENDING_TTL = 60 * 60 * 24 * 2
+
+# how long the trigger waits before trying again to reset a backend that was busy
+TRIGGER_RETRY = 60
+
+# the pre-chunking flag recording that an org's contacts have had their schemes pulled
+POPULATED_KEY = "schemes_populated:%d"
+
+
+def _update_contact_activities(org_id, by_scheme):
+    for scheme, uuids in by_scheme.items():
+        ContactActivity.objects.filter(org_id=org_id, contact__in=uuids).update(scheme=scheme)
+
+
+def _update_poll_results(org_id, by_scheme):
+    from ureport.polls.models import PollResult
+
+    for scheme, uuids in by_scheme.items():
+        # as the pre-chunking task did, this isn't scoped to the org - a contact uuid that two
+        # orgs' backends both know would have both orgs' results updated
+        PollResult.objects.filter(contact__in=uuids).update(scheme=scheme)
+
+
+# one of the one-off backfills that copy Contact.scheme onto the rows keyed by contact uuid.
+# both keep the pre-chunking task's cache keys - the done flag as a skip condition and dual
+# written on completion, the max id as a seed - so that neither redoes the other's work
+SchemesBackfill = namedtuple("SchemesBackfill", ("done_key", "cursor_key", "update_rows"))
+
+ACTIVITIES_BACKFILL = SchemesBackfill(
+    done_key="contact_activities_schemes_populated:%d",
+    cursor_key="contact_activities_schemes_max_id:%d",
+    update_rows=_update_contact_activities,
+)
+
+RESULTS_BACKFILL = SchemesBackfill(
+    done_key="poll_results_schemes_populated:%d",
+    cursor_key="poll_results_schemes_max_id:%d",
+    update_rows=_update_poll_results,
+)
+
+
+@chunked_task(REBUILD_JOB_TYPE, queue=QUEUE, lease_seconds=LEASE_SECONDS, name="contacts.rebuild_reporters_counts")
+def rebuild_reporters_counts(job):
+    """
+    Rebuilds one org's reporter counters. The recalculation replaces every counter the org has
+    in one go, so there is nothing finer to resume from - the job is a single chunk with a
+    lease long enough to cover it. It takes the contact pull lock for the same reason the
+    pre-chunking task did: the counters it replaces are the ones a running sync increments.
+    """
+    org = job.org
+    if not org:
+        return True
+
+    with contact_pull_lock(org, timeout=REBUILD_LOCK_TIMEOUT) as acquired:
+        if not acquired:
+            logger.info("Contact pull lock held for org #%d, backing off rebuild", org.pk)
+            return job.back_off(LOCK_BACKOFF, lock_backoffs=1)
+
+        Contact.recalculate_reporters_stats(org)
+        job.checkpoint(progress=job.add_progress(chunks=1))
+
+    return True
+
+
+def _run_schemes_chunk(job, backfill):
+    """
+    Runs one chunk of a schemes backfill: a bounded number of batches of the org's contacts,
+    in id order, with the id reached checkpointed after each batch. The row updates autocommit,
+    so a chunk that dies part way through replays from its last checkpoint - which costs
+    nothing, every update is last value wins.
+    """
+    org_id = job.org_id
+    if not org_id:
+        return True
+
+    if cache.get(backfill.done_key % org_id):
+        logger.info("Backfill %s already done for org #%d, skipping", job.job_type, org_id)
+        job.checkpoint(progress=job.add_progress(skipped=1))
+        return True
+
+    max_id = job.cursor.get("max_id")
+    if max_id is None:
+        # nothing resumed yet, so carry on from where the pre-chunking task got to - a batch
+        # behind it, as it wrote that position per contact rather than per completed batch
+        max_id = max(0, cache.get(backfill.cursor_key % org_id, 0) - BATCH_SIZE)
+
+    chunk_size = BATCH_SIZE * BATCHES_PER_CHUNK
+    contact_ids = list(
+        Contact.objects.filter(org_id=org_id, is_active=True, id__gt=max_id)
+        .exclude(scheme=None)
+        .exclude(scheme="")
+        .order_by("id")
+        .values_list("id", flat=True)[:chunk_size]
+    )
+
+    for batch in chunk_list(contact_ids, BATCH_SIZE):
+        batch_ids = list(batch)
+
+        # a batch is a handful of schemes over a thousand contacts, so it's one update per
+        # distinct scheme rather than one per contact
+        by_scheme = defaultdict(list)
+        for uuid, scheme in Contact.objects.filter(id__in=batch_ids).values_list("uuid", "scheme"):
+            by_scheme[scheme].append(uuid)
+
+        backfill.update_rows(org_id, by_scheme)
+
+        job.checkpoint(cursor={"max_id": batch_ids[-1]}, progress=job.add_progress(chunks=1, contacts=len(batch_ids)))
+        # dual written so that rolling back to the pre-chunking task resumes here too
+        cache.set(backfill.cursor_key % org_id, batch_ids[-1], None)
+
+    # a short chunk means there was nothing left behind it
+    return len(contact_ids) < chunk_size
+
+
+def _mark_backfill_done(job, backfill):
+    """
+    Dual writes the pre-chunking task's done flag, which is what both it and the trigger below
+    read to know an org is finished. Idempotent - only the flag's presence is ever read, so a
+    re-run rewriting the time it records costs nothing.
+    """
+    if not job.org_id:
+        return
+
+    cache.set(backfill.done_key % job.org_id, datetime_to_json_date(timezone.now()), None)
+
+
+def finalize_schemes_activities(job):
+    _mark_backfill_done(job, ACTIVITIES_BACKFILL)
+
+    # the pre-chunking task chained the poll results backfill after this one, and this is
+    # where that chain now lives
+    if job.org:
+        enqueue_schemes_results(job.org)
+
+
+def finalize_schemes_results(job):
+    _mark_backfill_done(job, RESULTS_BACKFILL)
+
+
+@chunked_task(
+    ACTIVITIES_JOB_TYPE,
+    queue=QUEUE,
+    lease_seconds=LEASE_SECONDS,
+    finalize=finalize_schemes_activities,
+    name="contacts.backfill_activities_schemes",
+)
+def backfill_activities_schemes(job):
+    return _run_schemes_chunk(job, ACTIVITIES_BACKFILL)
+
+
+@chunked_task(
+    RESULTS_JOB_TYPE,
+    queue=QUEUE,
+    lease_seconds=LEASE_SECONDS,
+    finalize=finalize_schemes_results,
+    name="contacts.backfill_results_schemes",
+)
+def backfill_results_schemes(job):
+    return _run_schemes_chunk(job, RESULTS_BACKFILL)
+
+
+def _enqueue_org_job(org, job_type):
+    """
+    Ensures this org has the given job and nudges it unless a run is already being driven.
+    Returns the job and whether it was nudged.
+    """
+    job = SyncJob.get_or_create_job(org, job_type)
+
+    if job.status == SyncJob.STATUS_PAUSED or in_flight(job, timezone.now()):
+        logger.info("Job #%d (%s) not nudged, %s", job.id, job_type, job.get_status_display())
+        return job, False
+
+    enqueue(job)
+    return job, True
+
+
+def enqueue_reporters_rebuilds(org_id=None):
+    """
+    Ensures a counter rebuild job exists and is enqueued for every active org, or for just the
+    one given. Returns the enqueued and skipped job ids by org id.
+    """
+    orgs = Org.objects.filter(is_active=True)
+    if org_id is not None:
+        orgs = orgs.filter(id=org_id)
+
+    enqueued = {}
+    skipped = {}
+
+    for org in orgs:
+        job, nudged = _enqueue_org_job(org, REBUILD_JOB_TYPE)
+        (enqueued if nudged else skipped)[org.id] = job.id
+
+    return {"enqueued": enqueued, "skipped": skipped}
+
+
+def enqueue_schemes_activities(org):
+    job, _ = _enqueue_org_job(org, ACTIVITIES_JOB_TYPE)
+    return job.id
+
+
+def enqueue_schemes_results(org):
+    job, _ = _enqueue_org_job(org, RESULTS_JOB_TYPE)
+    return job.id
+
+
+def start_schemes_backfill(org):
+    """
+    Triggers the one-off schemes backfill for an org. The half of the pre-chunking task that
+    re-pulled every contact so that they had schemes is superseded by the chunked contact
+    sync, so this asks that sync for a full re-pull instead and leaves a marker the sync's
+    finalization picks up.
+
+    The wait is deliberate. The backfill only visits contacts that already have a scheme and
+    never looks back at the ids it has passed, so running it alongside the re-pull that fills
+    those schemes in would silently leave gaps - and the done flag it sets on completion would
+    stop it ever revisiting them. Ordering the two, as the pre-chunking task did, is what
+    makes the flag safe to trust.
+
+    The marker is only left once every active backend has actually had its resume position
+    dropped. A backend still busy with an ordinary incremental run would otherwise finish it,
+    satisfy the wait, and have the backfill read contacts that were never re-pulled - so a
+    trigger that couldn't reset one comes back for it instead. With all the resets ahead of
+    the marker, a run completing after it either pulled the widened window or is a run that
+    started before it, which the wait ignores.
+    """
+    if is_pull_disabled(org):
+        # the per org kill switch the pre-chunking org task honored - without a pull there is
+        # nothing to re-pull with, and a marker left here would wait forever
+        logger.info("Contact pull disabled for org #%d, not starting schemes backfill", org.id)
+        return {"repulled": [], "skipped": [], "backfill": None, "disabled": True}
+
+    if cache.get(POPULATED_KEY % org.id):
+        logger.info("Contact schemes already pulled for org #%d, backfilling only", org.id)
+        return {"repulled": [], "skipped": [], "backfill": enqueue_schemes_activities(org)}
+
+    repulled, skipped = force_full_repull(org)
+
+    if skipped:
+        # resetting is idempotent, so the retry just picks up the ones left behind
+        logger.info("Backends %s busy for org #%d, retrying the schemes backfill trigger", skipped, org.id)
+        _retry_trigger(org)
+        return {"repulled": repulled, "skipped": skipped, "backfill": None, "retry_in": TRIGGER_RETRY}
+
+    if not repulled:
+        # nothing to re-pull from, so there is nothing for the backfill to wait on
+        return {"repulled": [], "skipped": [], "backfill": enqueue_schemes_activities(org)}
+
+    # marked after every re-pull is set up and before any is triggered, so that only a run
+    # whose window this trigger widened can satisfy the wait
+    cache.set(PENDING_KEY % org.id, datetime_to_json_date(timezone.now()), PENDING_TTL)
+    enqueue_org_syncs(org)
+
+    return {"repulled": repulled, "skipped": [], "backfill": None}
+
+
+def _retry_trigger(org):
+    # imported here as the shim it re-enqueues is the caller of this module
+    from ureport.contacts.tasks import populate_contact_schemes
+
+    populate_contact_schemes.apply_async((org.id,), queue=QUEUE, countdown=TRIGGER_RETRY)
+
+
+def resume_schemes_backfill(org):
+    """
+    Starts the schemes backfill an earlier trigger left pending, once every active backend of
+    the org has pulled its contacts afresh. Called from the contact sync's finalization, so it
+    runs on the completion of each backend's run until they have all had one.
+
+    Two finalizations racing here both start the backfill, which costs nothing - they nudge
+    the same job and the framework's claim lets only one run of it proceed.
+
+    Only used by the one-off schemes backfill trigger - remove it with the shims.
+    """
+    pending = cache.get(PENDING_KEY % org.id)
+    if not pending or not _pulled_since(org, json_date_to_datetime(pending)):
+        return
+
+    cache.delete(PENDING_KEY % org.id)
+
+    # the re-pull this waited for is what the flag records, and it's what stops a later
+    # trigger re-pulling the whole org again
+    cache.set(POPULATED_KEY % org.id, datetime_to_json_date(timezone.now()), None)
+
+    enqueue_schemes_activities(org)
+
+
+def _pulled_since(org, since):
+    """
+    Whether every active backend of the org has completed a contact sync run that started
+    after the given time - i.e. one that pulled with the widened window.
+    """
+    jobs = {job.scope: job for job in SyncJob.objects.filter(org=org, job_type=PULL_JOB_TYPE)}
+
+    for backend_obj in org.backends.filter(is_active=True):
+        job = jobs.get(backend_obj.slug)
+        if not job or job.status != SyncJob.STATUS_COMPLETE or not job.started_on or job.started_on < since:
+            return False
+
+    return True

--- a/ureport/contacts/sync.py
+++ b/ureport/contacts/sync.py
@@ -46,7 +46,7 @@ def _counts(prefix, counts):
     return {f"{prefix}_{key}": value for key, value in counts.items()}
 
 
-def _is_disabled(org):
+def is_pull_disabled(org):
     return TaskState.objects.filter(org=org, task_key=JOB_TYPE, is_disabled=True).exists()
 
 
@@ -94,6 +94,12 @@ def finalize_contacts_sync(job):
     state.is_failing = False
     state.save(update_fields=("started_on", "ended_on", "last_successfully_started_on", "last_results", "is_failing"))
 
+    # the one-off schemes backfill waits here because it reads what a pull writes - imported
+    # locally as the maintenance tasks build on this module
+    from ureport.contacts.maintenance import resume_schemes_backfill
+
+    resume_schemes_backfill(org)
+
 
 @chunked_task(
     JOB_TYPE, queue=QUEUE, lease_seconds=LEASE_SECONDS, finalize=finalize_contacts_sync, name="contacts.sync_contacts"
@@ -113,11 +119,11 @@ def sync_contacts(job):
         logger.info("Backend %s no longer active for org #%s, nothing to sync", job.scope, org.pk if org else None)
         return _abort_run(job, cursor)
 
-    if _is_disabled(org):
+    if is_pull_disabled(org):
         logger.info("Contact pull disabled for org #%d, stopping", org.pk)
         return _abort_run(job, cursor)
 
-    with _contact_pull_lock(org) as acquired:
+    with contact_pull_lock(org) as acquired:
         if not acquired:
             logger.info("Contact pull lock held for org #%d, backing off", org.pk)
             return job.back_off(LOCK_BACKOFF)
@@ -132,13 +138,17 @@ def sync_contacts(job):
             raise
 
 
-def _contact_pull_lock(org):
+def contact_pull_lock(org, timeout=LEASE_SECONDS):
     """
     The lock the ad-hoc contact tasks still coordinate through: two of them rebuild counters
     and need exclusive access, and the mismatch check reads it to tell a sync in progress
     from real drift.
+
+    The timeout must outlive the caller's lease, or a chunk that overruns its lease loses the
+    lock at the same moment another worker becomes free to claim the job, and the two run
+    concurrently - which is exactly what the lock is there to prevent.
     """
-    return chunk_lock(TaskState.get_lock_key(org, JOB_TYPE), LEASE_SECONDS)
+    return chunk_lock(TaskState.get_lock_key(org, JOB_TYPE), timeout)
 
 
 def _run_chunk(job, org, backend_obj, cursor):
@@ -217,6 +227,38 @@ def enqueue_org_syncs(org):
         enqueue(job)
 
     return {"enqueued": enqueued, "skipped": skipped}
+
+
+def force_full_repull(org):
+    """
+    Makes this org's next contact sync run pull its whole history again, by dropping both
+    resume positions a run can start from - the job cursor and the pre-chunking cache key it
+    seeds from. A job with a run being driven is left alone rather than having the window
+    pulled out from under it. Idempotent, so a caller that needs every backend reset can keep
+    trying until none are left alone. Returns the backend slugs reset and those left alone.
+
+    Only used by the one-off schemes backfill trigger - remove it with the shims.
+    """
+    now = timezone.now()
+    reset = []
+    skipped = []
+
+    for backend_obj in org.backends.filter(is_active=True):
+        job = SyncJob.get_or_create_job(org, JOB_TYPE, scope=backend_obj.slug)
+
+        # gated on the lease as well as on being in flight, so that a claim landing between
+        # the two wins rather than having the cursor pulled out from under it
+        if not in_flight(job, now) and SyncJob.objects.filter(id=job.id, lease_owner=None).update(cursor={}):
+            # only once the cursor is actually gone, or a refused reset would still drop the
+            # seed the next run would have resumed from
+            cache.delete(_last_fetched_key(org, backend_obj.slug))
+            reset.append(backend_obj.slug)
+            continue
+
+        logger.warning("Job #%d (%s:%s) is in flight, resume position left alone", job.id, JOB_TYPE, job.scope)
+        skipped.append(backend_obj.slug)
+
+    return reset, skipped
 
 
 @app.task(name="contacts.sync_contacts_dispatch")

--- a/ureport/contacts/tasks.py
+++ b/ureport/contacts/tasks.py
@@ -1,36 +1,40 @@
 # -*- coding: utf-8 -*-
 
-import time
-
 from celery.utils.log import get_task_logger
 from django_valkey import get_valkey_connection
 
 from django.core.cache import cache
-from django.utils import timezone
 
 from dash.orgs.models import Org, TaskState
 from dash.orgs.tasks import org_task
-from dash.utils.sync import SyncOutcome
 from ureport.celery import app
-from ureport.contacts.models import Contact, ReportersCounter
 
-# the chunked contact sync tasks live in sync.py - imported here so celery, which only
-# autodiscovers tasks modules, registers them
+# the chunked contact tasks live in sync.py and maintenance.py - imported here so celery,
+# which only autodiscovers tasks modules, registers them
+from ureport.contacts.maintenance import (  # noqa: F401
+    backfill_activities_schemes,
+    backfill_results_schemes,
+    enqueue_reporters_rebuilds,
+    enqueue_schemes_activities,
+    enqueue_schemes_results,
+    rebuild_reporters_counts,
+    start_schemes_backfill,
+)
+from ureport.contacts.models import Contact, ReportersCounter
 from ureport.contacts.sync import enqueue_org_syncs, sync_contacts, sync_contacts_dispatch  # noqa: F401
-from ureport.stats.models import ContactActivity
-from ureport.utils import chunk_list, datetime_to_json_date, update_cache_org_contact_counts
+from ureport.utils import update_cache_org_contact_counts
 
 logger = get_task_logger(__name__)
 
 
 @app.task(name="contacts.rebuild_contacts_counts")
-def rebuild_contacts_counts():
-    r = get_valkey_connection()
-    orgs = Org.objects.filter(is_active=True)
-    for org in orgs:
-        key = TaskState.get_lock_key(org, "contact-pull")
-        with r.lock(key, timeout=60 * 60 * 12):
-            Contact.recalculate_reporters_stats(org)
+def rebuild_contacts_counts(org_id=None):
+    """
+    Deprecated - kept for one release so existing triggers keep working. The rebuild itself is
+    now done per org by contacts.rebuild_reporters_counts, so this only ensures those jobs
+    exist and are enqueued - for one active org if given one, otherwise for all of them.
+    """
+    return enqueue_reporters_rebuilds(org_id=org_id)
 
 
 @app.task(name="contacts.check_contacts_count_mismatch")
@@ -92,191 +96,31 @@ def pull_contacts(org_id):
     return enqueue_org_syncs(org)
 
 
-@org_task("contact-pull", 60 * 60 * 24)
-def populate_contact_schemes(org, since, until):
-    r = get_valkey_connection()
-    start_time = time.time()
-
-    schemes_populated_key = f"schemes_populated:{org.id}"
-
-    if cache.get(schemes_populated_key):
-        logger.info(f"Skipping populating schemes for org #{org.id}")
-        populate_contact_activities_schemes.apply_async((org.id,), queue="slow")
-        return
-
-    logger.info(f"Starting populating schemes for org #{org.id}")
-
-    contact_pull_key = TaskState.get_lock_key(org, "contact-pull")
-
-    if Contact.objects.filter(org_id=org.id, scheme=None, is_active=True).exists():
-        # for ourself to make sure our task below will be run
-        r.delete(contact_pull_key)
-
-    with r.lock(contact_pull_key, timeout=60 * 60 * 24):
-        last_fetch_date_key = Contact.CONTACT_LAST_FETCHED_CACHE_KEY % (org.id, "rapidpro")
-        cache.delete(last_fetch_date_key)
-
-        backends = org.backends.filter(is_active=True)
-        for backend_obj in backends:
-            backend = org.get_backend(backend_slug=backend_obj.slug)
-
-            last_fetch_date_key = Contact.CONTACT_LAST_FETCHED_CACHE_KEY % (org.pk, backend_obj.slug)
-
-            until = datetime_to_json_date(timezone.now())
-            since = cache.get(last_fetch_date_key, None)
-
-            if not since:
-                logger.info("First time run for org #%d. Will sync all contacts" % org.pk)
-
-            start = time.time()
-
-            backend_fields_results = backend.pull_fields(org)
-
-            fields_created = backend_fields_results[SyncOutcome.created]
-            fields_updated = backend_fields_results[SyncOutcome.updated]
-            fields_deleted = backend_fields_results[SyncOutcome.deleted]
-            ignored = backend_fields_results[SyncOutcome.ignored]
-
-            logger.info(
-                "Fetched contact fields for org #%d. "
-                "Created %s, Updated %s, Deleted %d, Ignored %d"
-                % (org.pk, fields_created, fields_updated, fields_deleted, ignored)
-            )
-            logger.info("Fetch fields for org #%d took %ss" % (org.pk, time.time() - start))
-
-            start_boundaries = time.time()
-
-            backend_boundaries_results = backend.pull_boundaries(org)
-
-            boundaries_created = backend_boundaries_results[SyncOutcome.created]
-            boundaries_updated = backend_boundaries_results[SyncOutcome.updated]
-            boundaries_deleted = backend_boundaries_results[SyncOutcome.deleted]
-            ignored = backend_boundaries_results[SyncOutcome.ignored]
-
-            logger.info(
-                "Fetched boundaries for org #%d. "
-                "Created %s, Updated %s, Deleted %d, Ignored %d"
-                % (org.pk, boundaries_created, boundaries_updated, boundaries_deleted, ignored)
-            )
-
-            logger.info("Fetch boundaries for org #%d took %ss" % (org.pk, time.time() - start_boundaries))
-            start_contacts = time.time()
-
-            backend_contact_results, resume_cursor = backend.pull_contacts(org, since, until)
-
-            contacts_created = backend_contact_results[SyncOutcome.created]
-            contacts_updated = backend_contact_results[SyncOutcome.updated]
-            contacts_deleted = backend_contact_results[SyncOutcome.deleted]
-            ignored = backend_contact_results[SyncOutcome.ignored]
-
-            cache.set(last_fetch_date_key, until, None)
-
-            logger.info(
-                "Fetched contacts for org #%d. "
-                "Created %s, Updated %s, Deleted %d, Ignored %d"
-                % (org.pk, contacts_created, contacts_updated, contacts_deleted, ignored)
-            )
-
-            logger.info("Fetch contacts for org #%d took %ss" % (org.pk, time.time() - start_contacts))
-
-        Contact.recalculate_reporters_stats(org)
-
-    elapsed = time.time() - start_time
-    logger.info(f"Finished populating schemes on contacts for org #{org.id} in {elapsed:.1f} seconds")
-
-    contact_count_cache_updates_key = TaskState.get_lock_key(org, "update-org-contact-counts")
-    with r.lock(contact_count_cache_updates_key, timeout=60 * 20):
-        update_cache_org_contact_counts(org)
-
-    elapsed = time.time() - start_time
-    logger.info(f"Finished updating schemes counts on contacts for org #{org.id} in {elapsed:.1f} seconds")
-    cache.set(schemes_populated_key, datetime_to_json_date(timezone.now()), None)
-    populate_contact_activities_schemes.apply_async((org.id,), queue="slow")
+@app.task(name="ureport.contacts.tasks.populate_contact_schemes")
+def populate_contact_schemes(org_id):
+    """
+    Deprecated - kept for one release so existing triggers keep working. Its contact re-pull is
+    superseded by the chunked contact sync, so this only asks that sync for a full re-pull and
+    arranges for the schemes backfill to follow it.
+    """
+    return start_schemes_backfill(Org.objects.get(pk=org_id))
 
 
 @app.task(name="contacts.populate_contact_activities_schemes")
 def populate_contact_activities_schemes(org_id):
-    contact_activities_schemes_populated_key = f"contact_activities_schemes_populated:{org_id}"
-
-    if cache.get(contact_activities_schemes_populated_key):
-        logger.info(f"Skipping populating schemes for org #{org_id}")
-        populate_poll_results_schemes.apply_async((org_id,), queue="slow")
-        return
-
-    contact_activities_schemes_max_id_key = f"contact_activities_schemes_max_id:{org_id}"
-    max_id = cache.get(contact_activities_schemes_max_id_key, 0)
-
-    start_time = time.time()
-    logger.info(f"started populating schemes on contacts activities for org #{org_id}")
-    contact_ids = (
-        Contact.objects.filter(org_id=org_id, is_active=True, id__gt=max_id)
-        .exclude(scheme=None)
-        .exclude(scheme="")
-        .order_by("id")
-        .values_list("id", flat=True)
-    )
-
-    contacts_count = 0
-
-    for batch in chunk_list(contact_ids, 1000):
-        batch_ids = list(batch)
-        contacts = Contact.objects.filter(id__in=batch_ids)
-        for contact in contacts:
-            ContactActivity.objects.filter(org_id=contact.org_id, contact=contact.uuid).update(scheme=contact.scheme)
-            cache.set(contact_activities_schemes_max_id_key, contact.id, None)
-
-        contacts_count += len(batch_ids)
-
-        elapsed = time.time() - start_time
-        logger.info(
-            f"Populating schemes on contacts activities batch {contacts_count} for org #{org_id} in {elapsed:.1f} seconds"
-        )
-
-    elapsed = time.time() - start_time
-    logger.info(f"Finished populating schemes on contacts activities for org #{org_id} in {elapsed:.1f} seconds")
-    cache.set(contact_activities_schemes_populated_key, datetime_to_json_date(timezone.now()), None)
-    populate_poll_results_schemes.apply_async((org_id,), queue="slow")
+    """
+    Deprecated - kept for one release so existing triggers keep working. The backfill itself is
+    now done in resumable chunks by contacts.backfill_activities_schemes, so this only ensures
+    this org's job exists and is enqueued.
+    """
+    return enqueue_schemes_activities(Org.objects.get(pk=org_id))
 
 
 @app.task(name="contacts.populate_poll_results_schemes")
 def populate_poll_results_schemes(org_id):
-    from ureport.polls.models import PollResult
-
-    poll_results_schemes_populated_key = f"poll_results_schemes_populated:{org_id}"
-
-    if cache.get(poll_results_schemes_populated_key):
-        logger.info(f"Skipping populating schemes for org #{org_id}")
-        return
-
-    poll_results_schemes_max_id_key = f"poll_results_schemes_max_id:{org_id}"
-    max_id = cache.get(poll_results_schemes_max_id_key, 0)
-
-    start_time = time.time()
-    logger.info(f"started populating schemes on poll results for org #{org_id}")
-    contact_ids = (
-        Contact.objects.filter(org_id=org_id, is_active=True, id__gt=max_id)
-        .exclude(scheme=None)
-        .exclude(scheme="")
-        .order_by("id")
-        .values_list("id", flat=True)
-    )
-
-    contacts_count = 0
-
-    for batch in chunk_list(contact_ids, 1000):
-        batch_ids = list(batch)
-        contacts = Contact.objects.filter(id__in=batch_ids)
-        for contact in contacts:
-            PollResult.objects.filter(contact=contact.uuid).update(scheme=contact.scheme)
-            cache.set(poll_results_schemes_max_id_key, contact.id, None)
-
-        contacts_count += len(batch_ids)
-
-        elapsed = time.time() - start_time
-        logger.info(
-            f"Populating schemes on poll results batch {contacts_count} for org #{org_id} in {elapsed:.1f} seconds"
-        )
-
-    elapsed = time.time() - start_time
-    logger.info(f"Finished populating schemes on poll results for org #{org_id} in {elapsed:.1f} seconds")
-    cache.set(poll_results_schemes_populated_key, datetime_to_json_date(timezone.now()), None)
+    """
+    Deprecated - kept for one release so existing triggers keep working. The backfill itself is
+    now done in resumable chunks by contacts.backfill_results_schemes, so this only ensures
+    this org's job exists and is enqueued.
+    """
+    return enqueue_schemes_results(Org.objects.get(pk=org_id))

--- a/ureport/contacts/test_maintenance.py
+++ b/ureport/contacts/test_maintenance.py
@@ -1,0 +1,663 @@
+# -*- coding: utf-8 -*-
+
+from django_valkey import get_valkey_connection
+from mock import patch
+
+from django.core.cache import cache
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
+
+from dash.orgs.models import TaskState
+from ureport.contacts.maintenance import (
+    ACTIVITIES_BACKFILL,
+    ACTIVITIES_JOB_TYPE,
+    LEASE_SECONDS,
+    PENDING_KEY,
+    POPULATED_KEY,
+    REBUILD_JOB_TYPE,
+    REBUILD_LOCK_TIMEOUT,
+    RESULTS_BACKFILL,
+    RESULTS_JOB_TYPE,
+    TRIGGER_RETRY,
+    backfill_activities_schemes,
+    backfill_results_schemes,
+    rebuild_reporters_counts,
+    resume_schemes_backfill,
+)
+from ureport.contacts.models import Contact
+from ureport.contacts.sync import (
+    JOB_TYPE as PULL_JOB_TYPE,
+    LEASE_SECONDS as PULL_LEASE_SECONDS,
+    LOCK_BACKOFF,
+    finalize_contacts_sync,
+    sync_contacts,
+)
+from ureport.contacts.tasks import (
+    populate_contact_activities_schemes,
+    populate_contact_schemes,
+    populate_poll_results_schemes,
+    rebuild_contacts_counts,
+)
+from ureport.polls.models import PollResult
+from ureport.stats.models import ContactActivity
+from ureport.syncjobs.models import SyncJob
+from ureport.syncjobs.testing import (
+    SyncJobTestMixin,
+    drop_lease,
+    expire_lease,
+    held_lock,
+    hold_lease,
+    make_stale,
+    reload,
+    run_task,
+    run_to_completion,
+)
+from ureport.tests import UreportTest
+
+QUEUE = "slow"
+
+
+class MaintenanceTest(SyncJobTestMixin, UreportTest):
+    """
+    Shared plumbing: these jobs and the cache keys they carry over from the pre-chunking tasks
+    outlive a test, so each test starts from a clean slate.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.nigeria.backends.exclude(slug="rapidpro").delete()
+
+        for key in (
+            ACTIVITIES_BACKFILL.done_key,
+            ACTIVITIES_BACKFILL.cursor_key,
+            RESULTS_BACKFILL.done_key,
+            RESULTS_BACKFILL.cursor_key,
+            POPULATED_KEY,
+            PENDING_KEY,
+        ):
+            cache.delete(key % self.nigeria.id)
+            cache.delete(key % self.uganda.id)
+
+    def _task_states(self):
+        return TaskState.objects.filter(org__in=(self.nigeria, self.uganda))
+
+
+class RebuildReportersCountsTest(MaintenanceTest):
+    def setUp(self):
+        super().setUp()
+
+        self.job = SyncJob.get_or_create_job(self.nigeria, REBUILD_JOB_TYPE)
+
+    def _run(self, times=1):
+        return run_task(rebuild_reporters_counts, self.job.id, times=times)
+
+    @patch("ureport.contacts.models.Contact.recalculate_reporters_stats")
+    def test_rebuild_is_a_single_chunk(self, mock_recalculate):
+        self.assertEqual(run_to_completion(rebuild_reporters_counts, self.job.id), 1)
+
+        mock_recalculate.assert_called_once_with(self.nigeria)
+        self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE, progress={"chunks": 1}, lease_owner=None)
+
+        # the lock the contact tasks coordinate through is left released
+        self.assertIsNone(get_valkey_connection().get(TaskState.get_lock_key(self.nigeria, PULL_JOB_TYPE)))
+
+        # rebuilding counters isn't pulling, so it reports no pull in the org's task state
+        self.assertFalse(self._task_states().exists())
+
+    @patch("ureport.contacts.models.Contact.recalculate_reporters_stats")
+    def test_backs_off_while_a_contact_task_holds_the_lock(self, mock_recalculate):
+        with held_lock(TaskState.get_lock_key(self.nigeria, PULL_JOB_TYPE)):
+            mock_continue = self._run()
+
+        mock_continue.assert_called_once_with((self.job.id,), queue=QUEUE, countdown=LOCK_BACKOFF)
+        mock_recalculate.assert_not_called()
+
+        # a rebuild spinning on a busy org is visible in its progress
+        self.assertJobState(self.job, status=SyncJob.STATUS_RUNNING, progress={"lock_backoffs": 1})
+
+        # and the retry that follows the backoff does the rebuild
+        self._run()
+
+        mock_recalculate.assert_called_once_with(self.nigeria)
+        self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE, progress={"lock_backoffs": 1, "chunks": 1})
+
+    @patch("ureport.contacts.models.Contact.recalculate_reporters_stats")
+    def test_chunk_holds_the_lock_beyond_its_lease(self, mock_recalculate):
+        ttls = []
+        mock_recalculate.side_effect = lambda org: ttls.append(
+            get_valkey_connection().ttl(TaskState.get_lock_key(org, PULL_JOB_TYPE))
+        )
+
+        self._run()
+
+        # the lock has to outlast the lease, or it stops keeping a second worker out at the
+        # very moment the expiring lease lets one claim the job
+        self.assertGreater(ttls[0], LEASE_SECONDS)
+
+    @patch("ureport.contacts.models.Contact.recalculate_reporters_stats")
+    def test_reclaim_of_an_overrunning_rebuild_backs_off(self, mock_recalculate):
+        self.assertGreater(REBUILD_LOCK_TIMEOUT, LEASE_SECONDS)
+
+        # a rebuild that outran its lease: still holding the lock, no longer holding the job
+        self.job.claim("worker-1", lease_seconds=LEASE_SECONDS)
+        expire_lease(self.job)
+
+        with held_lock(TaskState.get_lock_key(self.nigeria, PULL_JOB_TYPE), timeout=REBUILD_LOCK_TIMEOUT):
+            mock_continue = self._run()
+
+        # the worker that reclaimed the job backs off instead of rebuilding the same counters
+        mock_recalculate.assert_not_called()
+        mock_continue.assert_called_once_with((self.job.id,), queue=QUEUE, countdown=LOCK_BACKOFF)
+
+    def test_shim_enqueues_a_job_per_active_org(self):
+        with patch.object(rebuild_reporters_counts, "apply_async") as mock_enqueue:
+            result = rebuild_contacts_counts()
+
+        jobs = {job.org_id: job.id for job in SyncJob.objects.filter(job_type=REBUILD_JOB_TYPE)}
+        self.assertEqual(set(jobs), {self.nigeria.id, self.uganda.id})
+        self.assertEqual(result, {"enqueued": jobs, "skipped": {}})
+        self.assertEqual({call[0][0][0] for call in mock_enqueue.call_args_list}, set(jobs.values()))
+        self.assertEqual(mock_enqueue.call_args_list[0][1], {"queue": QUEUE})
+
+        # enqueuing isn't rebuilding, so it must not report anything in the orgs' task states
+        self.assertFalse(self._task_states().exists())
+
+        # triggering again reuses the same jobs
+        with patch.object(rebuild_reporters_counts, "apply_async"):
+            rebuild_contacts_counts()
+
+        self.assertEqual(SyncJob.objects.filter(job_type=REBUILD_JOB_TYPE).count(), 2)
+
+    def test_shim_can_be_limited_to_one_org(self):
+        with patch.object(rebuild_reporters_counts, "apply_async") as mock_enqueue:
+            result = rebuild_contacts_counts(org_id=self.nigeria.id)
+
+        mock_enqueue.assert_called_once_with((self.job.id,), queue=QUEUE)
+        self.assertEqual(result, {"enqueued": {self.nigeria.id: self.job.id}, "skipped": {}})
+        self.assertFalse(SyncJob.objects.filter(job_type=REBUILD_JOB_TYPE, org=self.uganda).exists())
+
+    def test_shim_leaves_a_run_in_flight_alone(self):
+        hold_lease(self.job)
+
+        with patch.object(rebuild_reporters_counts, "apply_async") as mock_enqueue:
+            result = rebuild_contacts_counts(org_id=self.nigeria.id)
+
+        mock_enqueue.assert_not_called()
+        self.assertEqual(result, {"enqueued": {}, "skipped": {self.nigeria.id: self.job.id}})
+
+    def test_shim_skips_inactive_orgs(self):
+        self.uganda.is_active = False
+        self.uganda.save(update_fields=("is_active",))
+
+        with patch.object(rebuild_reporters_counts, "apply_async"):
+            result = rebuild_contacts_counts()
+
+        self.assertEqual(list(result["enqueued"]), [self.nigeria.id])
+
+
+class SchemesBackfillTest(MaintenanceTest):
+    """
+    Both backfills walk the org's contacts the same way, so the progression, resume and skip
+    cases are covered against the contact activities one and the poll results one is checked
+    for the rows it updates and the chain it ends.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.job = SyncJob.get_or_create_job(self.nigeria, ACTIVITIES_JOB_TYPE)
+        self.contacts = [self._create_contact(f"C-00{i}", "tel") for i in range(5)]
+
+        # a contact whose scheme the pull hasn't filled in - not this backfill's to copy
+        self.schemeless = self._create_contact("C-009", None)
+
+    def _create_contact(self, uuid, scheme, org=None):
+        org = org or self.nigeria
+        contact = Contact.objects.create(org=org, uuid=uuid, gender="M", born=1990, scheme=scheme)
+        ContactActivity.objects.create(org=org, contact=uuid, date=timezone.now().date())
+        PollResult.objects.create(org=org, flow="flow-1", ruleset="ruleset-1", contact=uuid, completed=False)
+        return contact
+
+    def _run(self, task=None, times=1):
+        """
+        Runs the backfill task, holding back both what it might ask a continuation of and the
+        backfill its finalization chains.
+        """
+        task = task or backfill_activities_schemes
+        with patch.object(backfill_results_schemes, "apply_async") as mock_chain:
+            mock_continue = run_task(task, self.job.id, times=times)
+        return mock_continue, mock_chain
+
+    def _activity_schemes(self):
+        return {a.contact: a.scheme for a in ContactActivity.objects.filter(org=self.nigeria)}
+
+    def _result_schemes(self):
+        return {r.contact: r.scheme for r in PollResult.objects.filter(org=self.nigeria)}
+
+    @patch("ureport.contacts.maintenance.BATCHES_PER_CHUNK", 2)
+    @patch("ureport.contacts.maintenance.BATCH_SIZE", 2)
+    def test_batches_progress_across_chunks(self):
+        # first chunk fills its two batches, so there may be more behind it
+        mock_continue, _ = self._run()
+
+        self.assertJobState(
+            self.job,
+            status=SyncJob.STATUS_RUNNING,
+            cursor={"max_id": self.contacts[3].id},
+            progress={"chunks": 2, "contacts": 4},
+        )
+        mock_continue.assert_called_once_with((self.job.id,), queue=QUEUE, countdown=None)
+
+        self.assertEqual(
+            self._activity_schemes(),
+            {"C-000": "tel", "C-001": "tel", "C-002": "tel", "C-003": "tel", "C-004": None, "C-009": None},
+        )
+
+        # the pre-chunking task's cursor is dual written so a rollback to it resumes here
+        self.assertEqual(cache.get(ACTIVITIES_BACKFILL.cursor_key % self.nigeria.id), self.contacts[3].id)
+
+        # the second chunk finishes the contacts and, being short, ends the run
+        mock_continue, mock_chain = self._run()
+
+        self.assertJobState(
+            self.job,
+            status=SyncJob.STATUS_COMPLETE,
+            cursor={"max_id": self.contacts[4].id},
+            progress={"chunks": 3, "contacts": 5},
+        )
+        mock_continue.assert_not_called()
+
+        # the schemeless contact is left for a run that comes after the pull that fills it in
+        self.assertEqual(self._activity_schemes()["C-004"], "tel")
+        self.assertIsNone(self._activity_schemes()["C-009"])
+
+        # completion dual writes the pre-chunking task's done flag and chains the next backfill
+        self.assertIsNotNone(cache.get(ACTIVITIES_BACKFILL.done_key % self.nigeria.id))
+
+        results_job = SyncJob.objects.get(org=self.nigeria, job_type=RESULTS_JOB_TYPE)
+        mock_chain.assert_called_once_with((results_job.id,), queue=QUEUE)
+
+    @patch("ureport.contacts.maintenance.BATCHES_PER_CHUNK", 1)
+    @patch("ureport.contacts.maintenance.BATCH_SIZE", 2)
+    def test_run_resumes_from_its_cursor(self):
+        self._run()
+        self.assertJobState(self.job, cursor={"max_id": self.contacts[1].id})
+
+        # as a worker that died mid run would, drop the lease and let another one take over
+        drop_lease(self.job)
+        self._run()
+
+        self.assertJobState(self.job, cursor={"max_id": self.contacts[3].id})
+        self.assertEqual(self._activity_schemes()["C-003"], "tel")
+        self.assertIsNone(self._activity_schemes()["C-004"])
+
+    @patch("ureport.contacts.maintenance.BATCHES_PER_CHUNK", 1)
+    @patch("ureport.contacts.maintenance.BATCH_SIZE", 2)
+    def test_first_chunk_seeds_from_legacy_max_id(self):
+        cache.set(ACTIVITIES_BACKFILL.cursor_key % self.nigeria.id, self.contacts[3].id, None)
+
+        self._run()
+
+        # the contacts the pre-chunking task already did aren't done again, bar the batch it
+        # may have died part way through - it wrote that position per contact, not per batch
+        self.assertJobState(self.job, cursor={"max_id": self.contacts[3].id})
+        self.assertEqual(
+            self._activity_schemes(),
+            {"C-000": None, "C-001": None, "C-002": "tel", "C-003": "tel", "C-004": None, "C-009": None},
+        )
+
+    def test_legacy_done_flag_skips_everything(self):
+        cache.set(ACTIVITIES_BACKFILL.done_key % self.nigeria.id, "2026-01-01T00:00:00.000Z", None)
+
+        _, mock_chain = self._run()
+
+        self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE, progress={"skipped": 1}, cursor={})
+        self.assertEqual(set(self._activity_schemes().values()), {None})
+
+        # the flag it skipped on is left set, refreshed with this run's own completion
+        done = cache.get(ACTIVITIES_BACKFILL.done_key % self.nigeria.id)
+        self.assertIsNotNone(done)
+        self.assertNotEqual(done, "2026-01-01T00:00:00.000Z")
+
+        # and the chain to the next backfill is what the pre-chunking task did here too
+        results_job = SyncJob.objects.get(org=self.nigeria, job_type=RESULTS_JOB_TYPE)
+        mock_chain.assert_called_once_with((results_job.id,), queue=QUEUE)
+
+    @patch("ureport.contacts.maintenance.BATCHES_PER_CHUNK", 1)
+    @patch("ureport.contacts.maintenance.BATCH_SIZE", 4)
+    def test_batch_updates_once_per_scheme(self):
+        self.contacts[1].scheme = "facebook"
+        self.contacts[1].save(update_fields=("scheme",))
+
+        with CaptureQueriesContext(connection) as queries:
+            self._run()
+
+        # a batch is a thousand contacts over a handful of schemes, so it's one update per
+        # distinct scheme rather than one per contact
+        updates = [q["sql"] for q in queries.captured_queries if 'UPDATE "stats_contactactivity"' in q["sql"]]
+        self.assertEqual(len(updates), 2)
+
+        self.assertEqual(self._activity_schemes()["C-001"], "facebook")
+        self.assertEqual(self._activity_schemes()["C-002"], "tel")
+
+    def test_backfill_is_scoped_to_its_org(self):
+        other = self._create_contact("C-100", "tel", org=self.uganda)
+
+        self._run()
+
+        self.assertIsNone(ContactActivity.objects.get(org=self.uganda, contact=other.uuid).scheme)
+        self.assertEqual(set(self._activity_schemes().values()), {"tel", None})
+
+    @patch("ureport.contacts.maintenance.BATCHES_PER_CHUNK", 1)
+    @patch("ureport.contacts.maintenance.BATCH_SIZE", 2)
+    def test_results_backfill_updates_poll_results(self):
+        self.job = SyncJob.get_or_create_job(self.nigeria, RESULTS_JOB_TYPE)
+
+        self._run(task=backfill_results_schemes)
+
+        self.assertJobState(self.job, status=SyncJob.STATUS_RUNNING)
+        self.assertEqual(self._result_schemes()["C-001"], "tel")
+        self.assertIsNone(self._result_schemes()["C-002"])
+        self.assertEqual(set(self._activity_schemes().values()), {None})
+
+        self.assertEqual(run_to_completion(backfill_results_schemes, self.job.id), 2)
+
+        self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE)
+        self.assertEqual(self._result_schemes()["C-004"], "tel")
+        self.assertIsNotNone(cache.get(RESULTS_BACKFILL.done_key % self.nigeria.id))
+
+        # nothing is chained after the last backfill
+        self.assertEqual(
+            SyncJob.objects.get(org=self.nigeria, job_type=ACTIVITIES_JOB_TYPE).status, SyncJob.STATUS_PENDING
+        )
+
+    def test_shims_only_enqueue(self):
+        with patch.object(backfill_activities_schemes, "apply_async") as mock_enqueue:
+            job_id = populate_contact_activities_schemes(self.nigeria.id)
+
+        job = SyncJob.objects.get(org=self.nigeria, job_type=ACTIVITIES_JOB_TYPE)
+        self.assertEqual(job_id, job.id)
+        mock_enqueue.assert_called_once_with((job.id,), queue=QUEUE)
+
+        with patch.object(backfill_results_schemes, "apply_async") as mock_enqueue:
+            job_id = populate_poll_results_schemes(self.nigeria.id)
+
+        job = SyncJob.objects.get(org=self.nigeria, job_type=RESULTS_JOB_TYPE)
+        self.assertEqual(job_id, job.id)
+        mock_enqueue.assert_called_once_with((job.id,), queue=QUEUE)
+
+        # neither backfilled anything itself, nor reported one in the org's task state
+        self.assertEqual(set(self._activity_schemes().values()), {None})
+        self.assertEqual(set(self._result_schemes().values()), {None})
+        self.assertFalse(self._task_states().exists())
+
+
+class SchemesBackfillTriggerTest(MaintenanceTest):
+    """
+    The pre-chunking trigger re-pulled every contact and only then backfilled their schemes.
+    The re-pull is now the chunked sync's, so the trigger asks it for one and the backfill
+    waits on it - it only copies schemes that are already there, and never revisits a contact
+    it has passed.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.pull_job = SyncJob.get_or_create_job(self.nigeria, PULL_JOB_TYPE, scope="rapidpro")
+        self.last_fetched_key = Contact.CONTACT_LAST_FETCHED_CACHE_KEY % (self.nigeria.pk, "rapidpro")
+        cache.delete(self.last_fetched_key)
+
+    def _trigger(self):
+        """
+        Runs the trigger, holding back everything it might enqueue: the contact pulls, the
+        backfill, and the retry of itself.
+        """
+        with patch.object(sync_contacts, "apply_async") as mock_pull:
+            with patch.object(backfill_activities_schemes, "apply_async") as mock_backfill:
+                with patch.object(populate_contact_schemes, "apply_async") as mock_retry:
+                    result = populate_contact_schemes(self.nigeria.id)
+        return result, mock_pull, mock_backfill, mock_retry
+
+    def _complete_pull(self, scope="rapidpro"):
+        """
+        Runs a contact sync run for the given backend through to its finalization, as a
+        completing chunk would.
+        """
+        job = SyncJob.get_or_create_job(self.nigeria, PULL_JOB_TYPE, scope=scope)
+        job.claim("worker-1")
+        job.checkpoint(cursor={"last_until": "2026-08-11T10:00:00.000Z"})
+        job.mark_complete()
+
+        with patch("ureport.contacts.sync.update_cache_org_contact_counts"):
+            with patch.object(backfill_activities_schemes, "apply_async") as mock_backfill:
+                finalize_contacts_sync(reload(job))
+
+        job.release_lease()
+        return mock_backfill
+
+    def test_trigger_forces_a_repull_the_backfill_then_waits_on(self):
+        SyncJob.objects.filter(id=self.pull_job.id).update(cursor={"last_until": "2026-08-10T10:00:00.000Z"})
+        cache.set(self.last_fetched_key, "2026-08-10T10:00:00.000Z", None)
+
+        result, mock_pull, mock_backfill, mock_retry = self._trigger()
+
+        self.assertEqual(result, {"repulled": ["rapidpro"], "skipped": [], "backfill": None})
+        mock_pull.assert_called_once_with((self.pull_job.id,), queue="celery")
+        mock_retry.assert_not_called()
+
+        # both resume positions are dropped so the run pulls everything again
+        self.assertJobState(self.pull_job, cursor={})
+        self.assertIsNone(cache.get(self.last_fetched_key))
+
+        # the backfill isn't started yet - it would skip past contacts the re-pull hasn't
+        # given a scheme to and never come back to them
+        mock_backfill.assert_not_called()
+        self.assertIsNotNone(cache.get(PENDING_KEY % self.nigeria.id))
+
+        # completing the re-pull is what starts it
+        mock_backfill = self._complete_pull()
+
+        backfill_job = SyncJob.objects.get(org=self.nigeria, job_type=ACTIVITIES_JOB_TYPE)
+        mock_backfill.assert_called_once_with((backfill_job.id,), queue=QUEUE)
+        self.assertIsNone(cache.get(PENDING_KEY % self.nigeria.id))
+
+        # and the re-pull it waited for is recorded, so triggering again doesn't redo it
+        self.assertIsNotNone(cache.get(POPULATED_KEY % self.nigeria.id))
+
+        result, mock_pull, _, _ = self._trigger()
+
+        self.assertEqual(result["repulled"], [])
+        mock_pull.assert_not_called()
+
+        # triggering it is not pulling, so it reports no pull in the org's task state
+        self.assertFalse(TaskState.objects.filter(org=self.nigeria, task_key=PULL_JOB_TYPE, is_failing=True).exists())
+
+    def test_trigger_skips_the_repull_once_schemes_are_populated(self):
+        cache.set(POPULATED_KEY % self.nigeria.id, "2026-01-01T00:00:00.000Z", None)
+        SyncJob.objects.filter(id=self.pull_job.id).update(cursor={"last_until": "2026-08-10T10:00:00.000Z"})
+
+        result, mock_pull, mock_backfill, _ = self._trigger()
+
+        backfill_job = SyncJob.objects.get(org=self.nigeria, job_type=ACTIVITIES_JOB_TYPE)
+        self.assertEqual(result, {"repulled": [], "skipped": [], "backfill": backfill_job.id})
+        mock_backfill.assert_called_once_with((backfill_job.id,), queue=QUEUE)
+
+        # the org's contacts already have their schemes, so nothing is re-pulled
+        mock_pull.assert_not_called()
+        self.assertJobState(self.pull_job, cursor={"last_until": "2026-08-10T10:00:00.000Z"})
+        self.assertIsNone(cache.get(PENDING_KEY % self.nigeria.id))
+
+    def test_trigger_refuses_while_the_pull_is_disabled(self):
+        TaskState.objects.create(org=self.nigeria, task_key=PULL_JOB_TYPE, is_disabled=True)
+        SyncJob.objects.filter(id=self.pull_job.id).update(cursor={"last_until": "2026-08-10T10:00:00.000Z"})
+
+        result, mock_pull, mock_backfill, mock_retry = self._trigger()
+
+        self.assertEqual(result, {"repulled": [], "skipped": [], "backfill": None, "disabled": True})
+        mock_pull.assert_not_called()
+        mock_backfill.assert_not_called()
+        mock_retry.assert_not_called()
+
+        # nothing is touched, and above all no wait is left that no pull can ever satisfy
+        self.assertJobState(self.pull_job, cursor={"last_until": "2026-08-10T10:00:00.000Z"})
+        self.assertIsNone(cache.get(PENDING_KEY % self.nigeria.id))
+
+    def test_trigger_retries_until_every_backend_is_reset(self):
+        self.pull_job.claim("worker-1")
+        self.pull_job.checkpoint(cursor={"stage": "contacts", "since": None, "until": "2026-08-11T10:00:00.000Z"})
+        cache.set(self.last_fetched_key, "2026-08-10T10:00:00.000Z", None)
+
+        result, mock_pull, _, mock_retry = self._trigger()
+
+        self.assertEqual(result, {"repulled": [], "skipped": ["rapidpro"], "backfill": None, "retry_in": TRIGGER_RETRY})
+        mock_retry.assert_called_once_with((self.nigeria.id,), queue=QUEUE, countdown=TRIGGER_RETRY)
+        mock_pull.assert_not_called()
+
+        # the window the run is part way through isn't pulled out from under it, nor is the
+        # seed it would resume from dropped
+        self.assertEqual(reload(self.pull_job).cursor["until"], "2026-08-11T10:00:00.000Z")
+        self.assertEqual(cache.get(self.last_fetched_key), "2026-08-10T10:00:00.000Z")
+
+        # and above all no wait is armed: this backend's ordinary incremental run would
+        # otherwise finish and pass the backfill data that was never re-pulled
+        self.assertIsNone(cache.get(PENDING_KEY % self.nigeria.id))
+
+        self._complete_pull().assert_not_called()
+        self.assertFalse(SyncJob.objects.filter(job_type=ACTIVITIES_JOB_TYPE).exists())
+
+        # the retry finds the backend free and resets it, and now the wait is armed
+        result, mock_pull, _, mock_retry = self._trigger()
+
+        self.assertEqual(result, {"repulled": ["rapidpro"], "skipped": [], "backfill": None})
+        mock_retry.assert_not_called()
+        mock_pull.assert_called_once_with((self.pull_job.id,), queue="celery")
+        self.assertIsNotNone(cache.get(PENDING_KEY % self.nigeria.id))
+
+        mock_backfill = self._complete_pull()
+
+        backfill_job = SyncJob.objects.get(org=self.nigeria, job_type=ACTIVITIES_JOB_TYPE)
+        mock_backfill.assert_called_once_with((backfill_job.id,), queue=QUEUE)
+
+    def test_reset_never_clobbers_a_claimed_job(self):
+        # a claimed job whose lease has expired but whose run nobody has taken over yet - not
+        # in flight, so only the lease guard stands between the reset and a live run's cursor
+        self.pull_job.claim("worker-1")
+        self.pull_job.checkpoint(cursor={"stage": "contacts", "since": None, "until": "2026-08-11T10:00:00.000Z"})
+        expire_lease(self.pull_job)
+        make_stale(self.pull_job, seconds_ago=2 * PULL_LEASE_SECONDS + 60)
+        cache.set(self.last_fetched_key, "2026-08-10T10:00:00.000Z", None)
+
+        result, _, _, mock_retry = self._trigger()
+
+        self.assertEqual(result["skipped"], ["rapidpro"])
+        mock_retry.assert_called_once()
+
+        # neither resume position is dropped, and no wait is armed on the strength of it
+        self.assertEqual(reload(self.pull_job).cursor["until"], "2026-08-11T10:00:00.000Z")
+        self.assertEqual(cache.get(self.last_fetched_key), "2026-08-10T10:00:00.000Z")
+        self.assertIsNone(cache.get(PENDING_KEY % self.nigeria.id))
+
+    def test_concurrent_finalizations_start_one_backfill(self):
+        self._trigger()
+        self._complete_pull()
+
+        # as a second backend's finalization racing the first would, with both reading the
+        # marker before either cleared it
+        cache.set(PENDING_KEY % self.nigeria.id, "2026-08-11T09:00:00.000Z", None)
+
+        with patch.object(backfill_activities_schemes, "apply_async") as mock_backfill:
+            resume_schemes_backfill(self.nigeria)
+
+        # they nudge the one job, and the framework's claim lets only one run of it proceed
+        backfill_job = SyncJob.objects.get(org=self.nigeria, job_type=ACTIVITIES_JOB_TYPE)
+        mock_backfill.assert_called_once_with((backfill_job.id,), queue=QUEUE)
+        self.assertEqual(SyncJob.objects.filter(job_type=ACTIVITIES_JOB_TYPE).count(), 1)
+
+    def test_backfill_waits_for_every_backend(self):
+        self.nigeria.backends.create(
+            slug="floip",
+            backend_type="ureport.backend.rapidpro.RapidProBackend",
+            api_token="token",
+            host="http://localhost:8001",
+            created_by=self.admin,
+            modified_by=self.admin,
+        )
+
+        result, _, _, _ = self._trigger()
+        self.assertEqual(sorted(result["repulled"]), ["floip", "rapidpro"])
+
+        # one backend done isn't every backend done
+        self._complete_pull("rapidpro").assert_not_called()
+        self.assertIsNotNone(cache.get(PENDING_KEY % self.nigeria.id))
+
+        mock_backfill = self._complete_pull("floip")
+
+        backfill_job = SyncJob.objects.get(org=self.nigeria, job_type=ACTIVITIES_JOB_TYPE)
+        mock_backfill.assert_called_once_with((backfill_job.id,), queue=QUEUE)
+
+    def test_run_that_predates_the_trigger_does_not_satisfy_the_wait(self):
+        self._trigger()
+
+        # a run started before the trigger widened the window pulled less than it asks for
+        cache.set(PENDING_KEY % self.nigeria.id, "2030-01-01T00:00:00.000Z", None)
+
+        self._complete_pull().assert_not_called()
+        self.assertIsNotNone(cache.get(PENDING_KEY % self.nigeria.id))
+
+    def test_completing_a_pull_without_a_pending_backfill_does_nothing(self):
+        mock_backfill = self._complete_pull()
+
+        mock_backfill.assert_not_called()
+        self.assertFalse(SyncJob.objects.filter(job_type=ACTIVITIES_JOB_TYPE).exists())
+
+    def test_trigger_without_an_active_backend_backfills_directly(self):
+        self.nigeria.backends.update(is_active=False)
+
+        result, mock_pull, mock_backfill, _ = self._trigger()
+
+        # there is no pull left to wait on, so waiting would strand the backfill
+        backfill_job = SyncJob.objects.get(org=self.nigeria, job_type=ACTIVITIES_JOB_TYPE)
+        self.assertEqual(result, {"repulled": [], "skipped": [], "backfill": backfill_job.id})
+        mock_backfill.assert_called_once_with((backfill_job.id,), queue=QUEUE)
+        mock_pull.assert_not_called()
+        self.assertIsNone(cache.get(PENDING_KEY % self.nigeria.id))
+
+
+class TaskNamesTest(UreportTest):
+    def test_registered_names_are_preserved(self):
+        self.assertEqual(rebuild_contacts_counts.name, "contacts.rebuild_contacts_counts")
+        self.assertEqual(populate_contact_schemes.name, "ureport.contacts.tasks.populate_contact_schemes")
+        self.assertEqual(populate_contact_activities_schemes.name, "contacts.populate_contact_activities_schemes")
+        self.assertEqual(populate_poll_results_schemes.name, "contacts.populate_poll_results_schemes")
+
+        self.assertEqual(rebuild_reporters_counts.name, "contacts.rebuild_reporters_counts")
+        self.assertEqual(backfill_activities_schemes.name, "contacts.backfill_activities_schemes")
+        self.assertEqual(backfill_results_schemes.name, "contacts.backfill_results_schemes")
+
+    def test_maintenance_jobs_run_on_the_slow_queue(self):
+        self.assertEqual(rebuild_reporters_counts.queue, QUEUE)
+        self.assertEqual(backfill_activities_schemes.queue, QUEUE)
+        self.assertEqual(backfill_results_schemes.queue, QUEUE)
+
+
+class StaleRunTest(MaintenanceTest):
+    def test_stale_run_is_nudged_again(self):
+        job = SyncJob.get_or_create_job(self.nigeria, REBUILD_JOB_TYPE)
+        job.claim("worker-1")
+        job.release_lease()
+
+        # between chunks with a continuation on its way - leave it be
+        with patch.object(rebuild_reporters_counts, "apply_async") as mock_enqueue:
+            rebuild_contacts_counts(org_id=self.nigeria.id)
+
+        mock_enqueue.assert_not_called()
+
+        # a run that stopped checkpointing entirely lost its continuation, so nudge it
+        make_stale(job, seconds_ago=2 * LEASE_SECONDS + 60)
+
+        with patch.object(rebuild_reporters_counts, "apply_async") as mock_enqueue:
+            rebuild_contacts_counts(org_id=self.nigeria.id)
+
+        mock_enqueue.assert_called_once_with((job.id,), queue=QUEUE)


### PR DESCRIPTION
Converts the contacts maintenance/backfill family to the resumable chunked sync framework. **Stacks on #1384** (the sync-job plumbing consolidation) — the diff includes its commit until it merges; review only the last commit here.

- **Reporter-counter rebuild** becomes a per-org job that still coordinates through the legacy contact-pull lock, taken with a timeout of twice the job lease so a slow recalculation can never race a second worker into doubled counters; if the lock is busy the chunk backs off (observably, counting backoffs into progress). The old all-orgs task name remains as an enqueue-only shim with an optional org filter.
- **The scheme backfills** (contact activities, poll results) become per-org chunked jobs: batches grouped into one UPDATE per distinct scheme (previously one per contact), cursors seeded defensively from the legacy cache positions, production done-flags respected as skip conditions and dual-written, and the chain between them preserved via completion hooks.
- **The backfill trigger** keeps its ordering guarantee under the new architecture: it refuses while the org's pull is disabled, resets every backend's pull cursor to force a full re-pull — retrying on a short countdown until in-flight runs clear, so the completion gate can never be satisfied by an ordinary incremental run (a review-proven silent-gap hazard) — then arms a TTL-bounded marker that the pull's completion hook checks per backend before starting the backfill. Concurrent completions collapse to a single backfill run.

As rebased onto #1384, the branch now uses the consolidated framework throughout: the shared non-blocking lock context manager, registry-routed enqueues, checkpoint's task-declared lease default, `job.back_off()` for lock contention, and the shared dispatch in-flight detection — its private copies of that plumbing are gone, and its tests use the shared sync-job test helpers.

Review-cycle highlights: the implementing agent correctly rejected relaxing the pull→backfill ordering (the backfill's cursor advances past schemeless contacts permanently, so concurrency would silently complete with gaps); the reviewer then proved the completion gate could still be bypassed when a reset was skipped mid-flight, which the retry loop closes. A mutation test pins the cursor-clear guard.

29 maintenance tests (128 green across contacts + syncjobs), covering the gate under busy backends, disabled orgs, lock-outlives-lease, seeding, flag dual-writes, chaining, and cross-scheme batch updates.