### PR TITLE
Convert the poll maintenance tasks to chunked resumable sync jobs

### DIFF
--- a/ureport/polls/sync.py
+++ b/ureport/polls/sync.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from dash.orgs.models import Org
 from ureport.celery import app
 from ureport.syncjobs.dispatch import Backoff, enqueue, is_due
+from ureport.syncjobs.locks import chunk_lock
 from ureport.syncjobs.models import SyncJob
 from ureport.syncjobs.tasks import chunked_task
 
@@ -16,12 +17,20 @@ logger = logging.getLogger(__name__)
 
 RESULTS_JOB_TYPE = "poll-results"
 ARCHIVES_JOB_TYPE = "poll-archives"
+COUNTS_JOB_TYPE = "counts-rebuild"
+PRUNE_JOB_TYPE = "poll-results-prune"
+AGE_GENDER_JOB_TYPE = "age-gender-backfill"
 
 SYNC_QUEUE = "sync"
+SLOW_QUEUE = "slow"
 
 # a results chunk is a bounded number of API pages, an archives chunk a single archive file
 RESULTS_LEASE_SECONDS = 60 * 30
 ARCHIVES_LEASE_SECONDS = 60 * 60 * 2
+
+# a maintenance chunk is a handful of polls, but one poll's rebuild or its results delete
+# can take a while on a big flow
+MAINTENANCE_LEASE_SECONDS = 60 * 30
 
 # how long to wait before the next chunk when the backend exhausted its rate limit
 RATE_LIMITED_BACKOFF = 300
@@ -46,6 +55,36 @@ FAILURE_BACKOFF = Backoff(base=timedelta(minutes=20), cap=timedelta(hours=24), m
 
 # other polls created this recently are covered by the recent polls cadence
 OTHER_POLLS_NEW_WINDOW = timedelta(days=7)
+
+# how stale a maintenance job's last run may be before its daily beat entry runs it again,
+# left short of a day so a run that started late isn't skipped the next day
+MAINTENANCE_INTERVAL = timedelta(hours=20)
+
+# how many polls a maintenance chunk walks - pruning is the heaviest, it deletes results
+COUNTS_CHUNK_SIZE = 5
+PRUNE_CHUNK_SIZE = 3
+AGE_GENDER_CHUNK_SIZE = 5
+
+# the age and gender backfill walks contacts a batch at a time, checkpointing each batch,
+# and does a few of them per chunk so a big org doesn't need a message per thousand contacts
+POPULATE_BATCH_SIZE = 1000
+POPULATE_BATCHES_PER_CHUNK = 5
+
+# results of polls whose date is older than this are dropped, unless the poll itself was
+# only created recently, i.e. it's an old poll someone is still setting up
+RESULTS_RETENTION = timedelta(days=365)
+NEW_POLL_WINDOW = timedelta(days=14)
+
+# an age and gender backfill populates the results, then rebuilds what they feed
+STAGE_POPULATE = "populate"
+STAGE_REBUILD = "rebuild"
+
+# what a prune did with a poll, kept apart in the job's counters so that a poll failing
+# every run is distinguishable from one that was merely busy
+PRUNE_CLEARED = "cleared"
+PRUNE_SKIPPED_SYNCING = "skipped_syncing"
+PRUNE_SKIPPED_RETIRED = "skipped_retired"
+PRUNE_ERRORED = "errors"
 
 
 def get_job_poll(org_id, flow_uuid):
@@ -75,6 +114,17 @@ def queue_archives_sync(org, flow_uuid, reset_cursor=False):
     Ensures the archives job for this flow exists and asks for a chunk of it to run.
     """
     return _queue(SyncJob.get_or_create_job(org, ARCHIVES_JOB_TYPE, flow_uuid), reset_cursor)
+
+
+def queue_maintenance(job_type, org=None):
+    """
+    Ensures the maintenance job of this type exists - one per org, or one install wide for a
+    job with no org - and asks for a chunk of it to run.
+    """
+    job = SyncJob.get_or_create_job(org, job_type)
+    enqueue(job)
+
+    return job
 
 
 def is_flow_syncing(org_id, flow_uuid):
@@ -380,5 +430,280 @@ def dispatch_flows(org, flow_uuids, interval=None, handled=None):
         if is_due(job, now, interval=interval, backoff=FAILURE_BACKOFF):
             _queue(job)
             queued.append(flow_uuid)
+
+    return queued
+
+
+# ------------------------------------------------------------------------------
+# Maintenance jobs: the periodic passes over polls that keep counts fresh, retire
+# polls too old to keep results for, and backfill segments onto existing results.
+# Each walks in pk (or contact id) order so a killed worker resumes where it
+# stopped. The counts rebuild and the prune are nudged by beat; the age and gender
+# backfill is only ever triggered by hand, as it was before, so re-triggering it is
+# also how a run stranded by a dead worker is picked back up - safe at any time,
+# since a job resumes from its cursor rather than starting the walk over.
+# ------------------------------------------------------------------------------
+
+
+@chunked_task(
+    COUNTS_JOB_TYPE, queue=SLOW_QUEUE, lease_seconds=MAINTENANCE_LEASE_SECONDS, name="polls.rebuild_poll_counts"
+)
+def rebuild_poll_counts(job):
+    """
+    Rebuilds the results counts of a bounded number of polls per chunk, across every org -
+    this is one install wide job, which is what replaces the multi day lock the unchunked
+    task held for the whole pass. Each run walks every syncing poll once, in pk order, and
+    the next run starts over from the first of them.
+    """
+    from ureport.polls.models import Poll
+
+    if job.new_run:
+        # a run has to cover every poll, so the position the last one left behind is dropped
+        # - durably, or a chunk that failed before its first checkpoint would leave the retry
+        # resuming below a completed run's position and walking nothing
+        job.checkpoint(cursor={})
+
+    after_pk = (job.cursor or {}).get("after_pk") or 0
+
+    # a poll that stopped syncing has no results left to count and its caches were rebuilt
+    # when it stopped, so this pass has nothing to keep fresh for it. The tradeoff is that
+    # retired polls lose the daily cache refresh they used to get: their cached results
+    # never expire and are recalculated on read, but a cache flush leaves them uncached
+    # until something asks for them
+    polls = list(
+        Poll.objects.filter(is_active=True, stopped_syncing=False, pk__gt=after_pk).order_by("pk")[:COUNTS_CHUNK_SIZE]
+    )
+    if not polls:
+        return True
+
+    for poll in polls:
+        poll.rebuild_poll_results_counts()
+
+        # checkpointed per poll rather than per chunk: rebuilding a big flow can take
+        # minutes, and a chunk that ran out of lease must not write on
+        job.checkpoint(cursor={"after_pk": poll.pk}, progress=job.add_progress(rebuilt=1))
+
+    return False
+
+
+@chunked_task(
+    PRUNE_JOB_TYPE, queue=SLOW_QUEUE, lease_seconds=MAINTENANCE_LEASE_SECONDS, name="polls.prune_poll_results"
+)
+def prune_poll_results(job):
+    """
+    Retires a bounded number of an org's polls that are too old to keep syncing: their
+    counts are rebuilt one last time, their results deleted, and every poll on the flow
+    marked as no longer syncing. Polls whose flow is still being synced are stepped over
+    rather than waited for, and reconsidered by a later run.
+    """
+    from ureport.polls.models import Poll
+
+    org = job.org
+    now = timezone.now()
+
+    if job.new_run:
+        # a run reconsiders every old poll, so it starts from the first of them - see
+        # rebuild_poll_counts for why that reset is checkpointed before any work
+        job.checkpoint(cursor={})
+
+    after_pk = (job.cursor or {}).get("after_pk") or 0
+
+    polls = list(
+        Poll.objects.filter(org=org, pk__gt=after_pk)
+        .exclude(poll_date__gte=now - RESULTS_RETENTION)
+        .exclude(created_on__gte=now - NEW_POLL_WINDOW)
+        .exclude(stopped_syncing=True)
+        .order_by("pk")[:PRUNE_CHUNK_SIZE]
+    )
+    if not polls:
+        return True
+
+    for poll in polls:
+        outcome = _clear_poll_results(org, poll)
+
+        # the position advances past a poll that was skipped or errored too, so that one
+        # unhappy poll can't stall everything behind it - the next run reconsiders it
+        job.checkpoint(cursor={"after_pk": poll.pk}, progress=job.add_progress(**{outcome: 1}))
+
+    return False
+
+
+def _clear_poll_results(org, poll):
+    """
+    Retires one poll, returning what became of it. A flow still being synced is left alone
+    - its results must not be deleted mid traversal - and so is a poll whose flow another
+    poll already retired, which is how the duplicated polls of a flow are recognised now
+    that a chunk can't carry a set of them forward in memory.
+    """
+    from ureport.polls.models import Poll
+
+    if is_flow_syncing(org.pk, poll.flow_uuid):
+        logger.info("Skipping clearing old results for poll #%d on org #%d as it is still syncing" % (poll.pk, org.pk))
+        return PRUNE_SKIPPED_SYNCING
+
+    # the valkey lock is only taken by the unchunked pulls, kept here for the release they
+    # still exist in - a chunked sync announces itself with its job lease instead
+    key = Poll.POLL_PULL_RESULTS_TASK_LOCK % (org.pk, poll.flow_uuid)
+
+    with chunk_lock(key, Poll.POLL_SYNC_LOCK_TIMEOUT) as acquired:
+        if not acquired:
+            logger.info(
+                "Skipping clearing old results for poll #%d on org #%d as it is still syncing" % (poll.pk, org.pk)
+            )
+            return PRUNE_SKIPPED_SYNCING
+
+        # refresh the object from the DB
+        poll.refresh_from_db()
+
+        if poll.stopped_syncing:
+            logger.info(
+                "Skipping clearing old results for poll #%d on org #%d as it appear to be duplicated"
+                % (poll.pk, org.pk)
+            )
+            return PRUNE_SKIPPED_RETIRED
+
+        try:
+            # one last stats rebuild for the poll, while its results are still there
+            poll.rebuild_poll_results_counts()
+
+            # retiring the flow before deleting its results, so that a delete interrupted
+            # part way leaves a flow that is durably retired on the counts just rebuilt,
+            # rather than one still syncing on results that are half gone
+            Poll.objects.filter(org=org, flow_uuid=poll.flow_uuid).update(stopped_syncing=True)
+            poll.delete_poll_results()
+
+            logger.info("Cleared poll results and stopped syncing for poll #%s on org #%s" % (poll.id, poll.org_id))
+        except Exception:
+            # one poll that fails every time would otherwise stall every poll after it, as
+            # the traversal can only move past polls it has finished with
+            logger.error(
+                "Error clearing old poll results for poll #%s on org #%s" % (poll.id, poll.org_id),
+                exc_info=True,
+                extra={"stack": True},
+            )
+            return PRUNE_ERRORED
+
+    return PRUNE_CLEARED
+
+
+@chunked_task(
+    AGE_GENDER_JOB_TYPE, queue=SLOW_QUEUE, lease_seconds=MAINTENANCE_LEASE_SECONDS, name="polls.backfill_age_gender"
+)
+def backfill_age_gender(job):
+    """
+    Backfills the age and gender of an org's poll results, then rebuilds the counts those
+    segments feed. Contacts are walked in id order a batch at a time, then the org's polls
+    in pk order. Contact ids are global and only ever grow, so the position the populate
+    pass reached is kept between runs and the next one carries on from it rather than
+    rewalking every contact the org has ever had.
+    """
+    from ureport.polls.models import Poll
+    from ureport.utils import LAST_POPULATED_CONTACT_KEY
+
+    org = job.org
+
+    if job.new_run:
+        # where a new run's populate pass starts: the position this job's last run reached,
+        # or for a job that has never run, the position the unchunked task left in its cache
+        # key. That key is only ever read - the walk it belongs to is retired
+        watermark = (job.cursor or {}).get("populate_watermark") or cache.get(LAST_POPULATED_CONTACT_KEY, 0) or 0
+
+        # checkpointed before any work for the same reason as rebuild_poll_counts: a chunk
+        # that failed before its first checkpoint must not leave the retry resuming from
+        # where the last run ended
+        cursor = {"stage": STAGE_POPULATE, "after_contact_id": watermark}
+        job.checkpoint(cursor=cursor)
+    else:
+        cursor = dict(job.cursor or {})
+
+    if cursor.get("stage") == STAGE_POPULATE:
+        return _populate_chunk(job, org, cursor)
+
+    after_pk = cursor.get("after_pk") or 0
+
+    polls = list(Poll.objects.filter(org=org, pk__gt=after_pk).order_by("pk")[:AGE_GENDER_CHUNK_SIZE])
+    if not polls:
+        return True
+
+    for poll in polls:
+        poll.rebuild_poll_results_counts()
+
+        job.checkpoint(
+            cursor={**cursor, "stage": STAGE_REBUILD, "after_pk": poll.pk}, progress=job.add_progress(rebuilt=1)
+        )
+
+    return False
+
+
+def _populate_chunk(job, org, cursor):
+    """
+    Copies age and gender onto the results of a few batches of the org's contacts, each
+    batch checkpointed and renewing the lease, so an interrupted pass resumes at the batch
+    it stopped on instead of starting the org's contacts over.
+    """
+    from ureport.contacts.models import Contact
+    from ureport.utils import populate_age_and_gender_for_contacts
+
+    after_contact_id = cursor.get("after_contact_id") or 0
+
+    for _ in range(POPULATE_BATCHES_PER_CHUNK):
+        contact_ids = list(
+            Contact.objects.filter(org=org, id__gt=after_contact_id)
+            .order_by("id")
+            .values_list("id", flat=True)[:POPULATE_BATCH_SIZE]
+        )
+
+        if not contact_ids:
+            # the contacts are exhausted, so how far this pass got becomes where the next
+            # run starts, and the counts these segments feed are rebuilt next
+            job.checkpoint(cursor={"stage": STAGE_REBUILD, "populate_watermark": after_contact_id})
+            return False
+
+        populate_age_and_gender_for_contacts(contact_ids)
+        after_contact_id = contact_ids[-1]
+
+        job.checkpoint(
+            cursor={"stage": STAGE_POPULATE, "after_contact_id": after_contact_id},
+            progress=job.add_progress(populated=len(contact_ids)),
+        )
+
+    return False
+
+
+@app.task(name="polls.rebuild_counts_dispatch")
+def rebuild_counts_dispatch():
+    """
+    Nudges the install wide counts rebuild job. A pass still working through its polls when
+    the next one comes round is left to its own continuations rather than started again,
+    and a failing one backs off. Returns the job id if it was queued.
+    """
+    job = SyncJob.get_or_create_job(None, COUNTS_JOB_TYPE)
+
+    if not is_due(job, timezone.now(), interval=MAINTENANCE_INTERVAL, backoff=FAILURE_BACKOFF):
+        logger.info("Job #%d (%s) not queued, %s" % (job.id, COUNTS_JOB_TYPE, job.get_status_display()))
+        return None
+
+    enqueue(job)
+    return job.id
+
+
+@app.task(name="polls.prune_results_dispatch")
+def prune_results_dispatch(org_id=None):
+    """
+    Nudges the old results prune job of every active org that is due for one. Returns the
+    orgs actually queued.
+    """
+    orgs = Org.objects.filter(is_active=True)
+    if org_id:
+        orgs = orgs.filter(id=org_id)
+
+    now = timezone.now()
+    queued = []
+
+    for org in orgs:
+        job = SyncJob.get_or_create_job(org, PRUNE_JOB_TYPE)
+        if is_due(job, now, interval=MAINTENANCE_INTERVAL, backoff=FAILURE_BACKOFF):
+            enqueue(job)
+            queued.append(org.pk)
 
     return queued

--- a/ureport/polls/tasks.py
+++ b/ureport/polls/tasks.py
@@ -2,24 +2,30 @@
 
 import logging
 import time
-from datetime import timedelta
 
 from django_valkey import get_valkey_connection
 
 from django.utils import timezone
 
 from dash.orgs.models import Org
-from dash.orgs.tasks import org_task
 from ureport.celery import app
 from ureport.polls.sync import (  # noqa: F401 - imported here so the worker registers the chunked tasks
+    AGE_GENDER_JOB_TYPE,
+    COUNTS_JOB_TYPE,
     MAIN_POLL_INTERVAL,
     OTHER_POLLS_INTERVAL,
     OTHER_POLLS_NEW_WINDOW,
+    PRUNE_JOB_TYPE,
     RECENT_POLLS_INTERVAL,
+    backfill_age_gender,
     dispatch_flows,
-    is_flow_syncing,
+    prune_poll_results,
+    prune_results_dispatch,
     queue_archives_sync,
+    queue_maintenance,
     queue_results_sync,
+    rebuild_counts_dispatch,
+    rebuild_poll_counts,
     sync_poll_archives,
     sync_poll_results,
     sync_polls_dispatch,
@@ -28,7 +34,6 @@ from ureport.utils import (
     fetch_flows,
     fetch_old_sites_count as do_fetch_old_sites_count,
     fetch_shared_sites_count,
-    populate_age_and_gender_poll_results,
     update_poll_flow_data,
 )
 
@@ -87,58 +92,11 @@ def pull_results_recent_polls(org_id):
     _queue_polls(org, Poll.get_recent_polls(org), interval=RECENT_POLLS_INTERVAL)
 
 
-@org_task("clear-old-poll-results", 60 * 60 * 5)
-def clear_old_poll_results(org, since, until):
-    from .models import Poll
+@app.task(name="ureport.polls.tasks.clear_old_poll_results")
+def clear_old_poll_results(org_id):
+    org = Org.objects.get(pk=org_id)
 
-    now = timezone.now()
-    r = get_valkey_connection()
-    syncing_window = now - timedelta(days=365)
-    new_window = now - timedelta(days=14)
-
-    dupes_flow_uuid = set()
-
-    old_polls = (
-        Poll.objects.filter(org=org)
-        .exclude(poll_date__gte=syncing_window)
-        .exclude(created_on__gte=new_window)
-        .exclude(stopped_syncing=True)
-        .order_by("pk")
-    )
-    for poll in old_polls:
-        key = Poll.POLL_PULL_RESULTS_TASK_LOCK % (org.pk, poll.flow_uuid)
-        # the valkey lock is only taken by the unchunked pulls, kept here for the release
-        # they still exist in - a chunked sync announces itself with its job lease instead
-        if r.get(key) or is_flow_syncing(org.pk, poll.flow_uuid):
-            logger.info(
-                "Skipping clearing old results for poll #%d on org #%d as it is still syncing" % (poll.pk, org.pk)
-            )
-        elif poll.flow_uuid in dupes_flow_uuid:
-            logger.info(
-                "Skipping clearing old results for poll #%d on org #%d as it appear to be duplicated"
-                % (poll.pk, org.pk)
-            )
-        else:
-            dupes_flow_uuid.add(poll.flow_uuid)
-            with r.lock(key, timeout=Poll.POLL_SYNC_LOCK_TIMEOUT):
-                # refresh the object from the DB
-                poll.refresh_from_db()
-                try:
-                    # one last stats rebuild for the poll
-                    poll.rebuild_poll_results_counts()
-
-                    if not poll.stopped_syncing:
-                        poll.delete_poll_results()
-                        Poll.objects.filter(org=org, flow_uuid=poll.flow_uuid).update(stopped_syncing=True)
-                        logger.info(
-                            "Cleared poll results and stopped syncing for poll #%s on org #%s" % (poll.id, poll.org_id)
-                        )
-                except Exception:
-                    logger.error(
-                        "Error clearing old poll results for poll #%s on org #%s" % (poll.id, poll.org_id),
-                        exc_info=True,
-                        extra={"stack": True},
-                    )
+    queue_maintenance(PRUNE_JOB_TYPE, org)
 
 
 # acks late so an admin-triggered action interrupted by a worker stop is redelivered
@@ -184,45 +142,15 @@ def pull_refresh_from_archives(poll_id):
 
 @app.task(name="polls.rebuild_counts")
 def rebuild_counts():
-    from .models import Poll
-
-    r = get_valkey_connection()
-
-    key = "polls_rebuild_counts_task_running"
-    lock_timeout = 60 * 60 * 24 * 4  # 4 days
-
-    if r.get(key):
-        logger.info("Task: polls.rebuild_counts skipped")
-    else:
-        with r.lock(key, timeout=lock_timeout):
-            start_time = time.time()
-
-            logger.info("Task: polls.rebuild_counts started")
-            polls = Poll.objects.filter(is_active=True)
-
-            for poll in polls:
-                poll.rebuild_poll_results_counts()
-
-            elapsed = time.time() - start_time
-
-            logger.info(f"Task: polls.rebuild_counts finished in {elapsed:.1f} seconds")
+    queue_maintenance(COUNTS_JOB_TYPE)
 
 
 @app.task(name="update_results_age_gender")
 def update_results_age_gender(org_id=None):
-    from .models import Poll
+    orgs = Org.objects.filter(pk=org_id) if org_id else Org.objects.filter(is_active=True)
 
-    org = None
-    if org_id:
-        org = Org.objects.filter(pk=org_id).first()
-
-    populate_age_and_gender_poll_results(org)
-
-    polls = Poll.objects.all()
-    if org:
-        polls = polls.filter(org=org)
-    for poll in polls:
-        poll.rebuild_poll_results_counts()
+    for org in orgs:
+        queue_maintenance(AGE_GENDER_JOB_TYPE, org)
 
 
 @app.task(name="polls.refresh_org_flows")

--- a/ureport/polls/test_sync.py
+++ b/ureport/polls/test_sync.py
@@ -5,18 +5,28 @@ from datetime import timedelta, timezone as tzone
 from mock import patch
 
 from django.core.cache import cache
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 
 from dash.categories.models import Category
-from dash.orgs.models import TaskState
+from dash.orgs.models import Org, TaskState
 from ureport.backend import ChunkResult
 from ureport.backend.rapidpro import RapidProBackend
+from ureport.contacts.models import Contact
 from ureport.polls.models import Poll, PollResult
 from ureport.polls.sync import (
+    AGE_GENDER_JOB_TYPE,
     ARCHIVES_JOB_TYPE,
+    COUNTS_JOB_TYPE,
+    PRUNE_JOB_TYPE,
     RATE_LIMITED_BACKOFF,
     RESULTS_JOB_TYPE,
+    backfill_age_gender,
     dispatch_org_polls,
+    prune_poll_results,
+    prune_results_dispatch,
+    rebuild_counts_dispatch,
+    rebuild_poll_counts,
     sync_poll_archives,
     sync_poll_results,
     sync_polls_dispatch,
@@ -29,12 +39,23 @@ from ureport.polls.tasks import (
     pull_results_main_poll,
     pull_results_other_polls,
     pull_results_recent_polls,
+    rebuild_counts,
+    update_results_age_gender,
 )
 from ureport.polls.views import PollCRUDL
 from ureport.syncjobs.models import SyncJob
-from ureport.syncjobs.testing import SyncJobTestMixin, drop_lease, end_run, hold_lease, make_stale, run_task
+from ureport.syncjobs.testing import (
+    SyncJobTestMixin,
+    drop_lease,
+    end_run,
+    held_lock,
+    hold_lease,
+    make_stale,
+    reload,
+    run_task,
+)
 from ureport.tests import UreportTest
-from ureport.utils import datetime_to_json_date
+from ureport.utils import LAST_POPULATED_CONTACT_KEY, datetime_to_json_date
 
 
 def results_counts(**overrides):
@@ -688,36 +709,591 @@ class TaskShimTest(PollSyncTestBase):
         self.assertFalse(TaskState.objects.filter(org=self.nigeria).exists())
 
 
-class ClearOldResultsTest(PollSyncTestBase):
+class RebuildPollCountsTest(PollSyncTestBase):
     def setUp(self):
-        super(ClearOldResultsTest, self).setUp()
+        super(RebuildPollCountsTest, self).setUp()
 
-        Poll.objects.filter(id=self.poll.id).update(
-            poll_date=timezone.now() - timedelta(days=500), created_on=timezone.now() - timedelta(days=500)
+        self.health_uganda = Category.objects.create(
+            org=self.uganda, name="Health", created_by=self.admin, modified_by=self.admin
         )
 
-    def clear(self):
+        self.polls = [self.poll]
+        for index in range(2, 7):
+            self.polls.append(
+                self.create_poll(self.nigeria, "Poll %d" % index, "uuid-%d" % index, self.education_nigeria, self.admin)
+            )
+
+        # the counts rebuild is one install wide job, so another org's polls are in its walk
+        self.polls.append(self.create_poll(self.uganda, "Poll UG", "uuid-ug", self.health_uganda, self.admin))
+
+        self.job = SyncJob.get_or_create_job(None, COUNTS_JOB_TYPE)
+
+    def rebuild(self):
+        with patch.object(Poll, "rebuild_poll_results_counts", autospec=True) as mock_rebuild:
+            mock_continue = run_task(rebuild_poll_counts, self.job.id)
+
+        return [call[0][0].pk for call in mock_rebuild.call_args_list], mock_continue
+
+    def test_walks_every_poll_a_chunk_at_a_time(self):
+        self.assertIsNone(self.job.org_id)
+
+        rebuilt, mock_continue = self.rebuild()
+
+        self.assertEqual(rebuilt, [poll.pk for poll in self.polls[:5]])
+        mock_continue.assert_called_once_with((self.job.id,), queue="slow", countdown=None)
+
+        self.assertJobState(
+            self.job,
+            status=SyncJob.STATUS_RUNNING,
+            cursor={"after_pk": self.polls[4].pk},
+            progress={"rebuilt": 5},
+        )
+
+        # the continuation picks up from the checkpointed position
+        rebuilt, mock_continue = self.rebuild()
+
+        self.assertEqual(rebuilt, [poll.pk for poll in self.polls[5:]])
+        mock_continue.assert_called_once()
+
+        # and the run ends once the polls are exhausted
+        rebuilt, mock_continue = self.rebuild()
+
+        self.assertEqual(rebuilt, [])
+        mock_continue.assert_not_called()
+        self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE, progress={"rebuilt": 7})
+
+    def test_skips_polls_with_nothing_to_count(self):
+        Poll.objects.filter(id=self.polls[1].id).update(stopped_syncing=True)
+        Poll.objects.filter(id=self.polls[2].id).update(is_active=False)
+
+        rebuilt, _ = self.rebuild()
+
+        self.assertEqual(rebuilt, [self.polls[index].pk for index in (0, 3, 4, 5, 6)])
+
+    def test_resumes_where_a_killed_chunk_stopped(self):
+        with (
+            patch.object(rebuild_poll_counts, "apply_async"),
+            patch.object(Poll, "rebuild_poll_results_counts", autospec=True) as mock_rebuild,
+        ):
+            mock_rebuild.side_effect = [None, None, ValueError("worker died")]
+
+            with self.assertRaises(ValueError):
+                rebuild_poll_counts(self.job.id)
+
+        self.assertJobState(
+            self.job,
+            status=SyncJob.STATUS_FAILED,
+            cursor={"after_pk": self.polls[1].pk},
+            progress={"rebuilt": 2},
+        )
+
+        # the retry resumes the interrupted run rather than rebuilding those two again
+        rebuilt, _ = self.rebuild()
+
+        self.assertEqual(rebuilt, [poll.pk for poll in self.polls[2:]])
+        self.assertJobState(self.job, progress={"rebuilt": 7})
+
+    def completed_run(self):
+        """
+        Leaves the job as a run that covered every poll a day ago, i.e. the state a new run
+        of it has to recognise as one it must not resume below.
+        """
+        return end_run(
+            self.job,
+            cursor={"after_pk": self.polls[-1].pk},
+            progress={"rebuilt": 7},
+            ended_on=timezone.now() - timedelta(days=1),
+        )
+
+    def test_a_new_run_starts_from_the_first_poll(self):
+        # a completed run leaves its position behind, and resuming below it would walk nothing
+        self.completed_run()
+
+        rebuilt, _ = self.rebuild()
+
+        self.assertEqual(rebuilt, [poll.pk for poll in self.polls[:5]])
+        self.assertJobState(self.job, progress={"rebuilt": 5})
+
+    def test_a_new_run_that_fails_before_its_first_checkpoint_still_starts_over(self):
+        self.completed_run()
+
+        with (
+            patch.object(rebuild_poll_counts, "apply_async"),
+            patch.object(Poll, "rebuild_poll_results_counts", autospec=True) as mock_rebuild,
+        ):
+            mock_rebuild.side_effect = ValueError("worker died")
+
+            with self.assertRaises(ValueError):
+                rebuild_poll_counts(self.job.id)
+
+        # the run dropped the completed one's position before touching a poll, so the stale
+        # position can't survive a chunk that fails before checkpointing anything itself
+        self.assertJobState(self.job, status=SyncJob.STATUS_FAILED, cursor={})
+
+        # and the retry, which resumes that run rather than starting one, still walks it all
+        rebuilt, _ = self.rebuild()
+
+        self.assertEqual(rebuilt, [poll.pk for poll in self.polls[:5]])
+
+    def test_a_lost_lease_leaves_the_polls_already_done_checkpointed(self):
+        def steal(poll):
+            if poll.pk == self.polls[1].pk:
+                SyncJob.objects.filter(id=self.job.id).update(lease_owner="worker-2")
+
+        with patch.object(Poll, "rebuild_poll_results_counts", autospec=True) as mock_rebuild:
+            mock_rebuild.side_effect = steal
+
+            mock_continue = run_task(rebuild_poll_counts, self.job.id)
+
+        # the chunk is dropped where it lost the lease, but the poll it had already
+        # checkpointed is not walked again by whoever took over
+        self.assertJobState(self.job, status=SyncJob.STATUS_RUNNING, cursor={"after_pk": self.polls[0].pk})
+        mock_continue.assert_not_called()
+
+    def test_only_one_global_job_can_exist(self):
+        with self.assertRaises(IntegrityError), transaction.atomic():
+            SyncJob.objects.create(org=None, job_type=COUNTS_JOB_TYPE, scope="")
+
+
+class PrunePollResultsTest(PollSyncTestBase):
+    def setUp(self):
+        super(PrunePollResultsTest, self).setUp()
+
+        # a duplicate poll on the same flow, and two polls of their own
+        self.dupe = self.create_poll(self.nigeria, "Poll 1 again", "uuid-1", self.education_nigeria, self.admin)
+        self.second = self.create_poll(self.nigeria, "Poll 2", "uuid-2", self.education_nigeria, self.admin)
+        self.third = self.create_poll(self.nigeria, "Poll 3", "uuid-3", self.education_nigeria, self.admin)
+
+        self.old_polls = [self.poll, self.dupe, self.second, self.third]
+
+        long_ago = timezone.now() - timedelta(days=500)
+        Poll.objects.filter(id__in=[poll.id for poll in self.old_polls]).update(poll_date=long_ago, created_on=long_ago)
+
+        self.job = SyncJob.get_or_create_job(self.nigeria, PRUNE_JOB_TYPE)
+
+    def prune(self):
         with (
             patch.object(Poll, "rebuild_poll_results_counts"),
-            patch.object(Poll, "delete_poll_results") as mock_delete,
+            patch.object(Poll, "delete_poll_results", autospec=True) as mock_delete,
         ):
-            clear_old_poll_results(self.nigeria.pk)
+            mock_continue = run_task(prune_poll_results, self.job.id)
 
-        return mock_delete
+        return [call[0][0].pk for call in mock_delete.call_args_list], mock_continue
 
-    def test_leaves_a_flow_alone_while_its_sync_holds_the_lease(self):
+    def stopped(self):
+        return set(Poll.objects.filter(stopped_syncing=True).values_list("pk", flat=True))
+
+    def test_retires_each_flow_once_a_chunk_at_a_time(self):
+        pruned, mock_continue = self.prune()
+
+        # the duplicate poll of the first flow is recognised by the flow already being stopped
+        self.assertEqual(pruned, [self.poll.pk, self.second.pk])
+        mock_continue.assert_called_once_with((self.job.id,), queue="slow", countdown=None)
+
+        self.assertJobState(
+            self.job, cursor={"after_pk": self.second.pk}, progress={"cleared": 2, "skipped_retired": 1}
+        )
+        self.assertEqual(self.stopped(), {self.poll.pk, self.dupe.pk, self.second.pk})
+
+        # the continuation takes the poll the chunk stopped at
+        pruned, _ = self.prune()
+
+        self.assertEqual(pruned, [self.third.pk])
+        self.assertEqual(self.stopped(), {poll.pk for poll in self.old_polls})
+
+        pruned, mock_continue = self.prune()
+
+        self.assertEqual(pruned, [])
+        mock_continue.assert_not_called()
+        self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE)
+
+    def test_leaves_recent_polls_alone(self):
+        Poll.objects.filter(id=self.second.id).update(poll_date=timezone.now() - timedelta(days=10))
+        # an old poll only just created is someone still setting it up
+        Poll.objects.filter(id=self.third.id).update(created_on=timezone.now() - timedelta(days=2))
+
+        pruned, _ = self.prune()
+
+        self.assertEqual(pruned, [self.poll.pk])
+        self.assertEqual(self.stopped(), {self.poll.pk, self.dupe.pk})
+
+    def test_steps_over_a_flow_that_is_still_syncing(self):
         job = SyncJob.get_or_create_job(self.nigeria, RESULTS_JOB_TYPE, "uuid-1")
         SyncJob.objects.filter(id=job.id).update(status=SyncJob.STATUS_RUNNING)
         hold_lease(job)
 
-        self.clear().assert_not_called()
-        self.assertFalse(Poll.objects.get(id=self.poll.id).stopped_syncing)
+        # the syncing flow is skipped, but the polls behind it in the walk are not held up
+        pruned, _ = self.prune()
 
-        # once the lease is gone the results can be cleared
+        self.assertEqual(pruned, [self.second.pk])
+        self.assertEqual(self.stopped(), {self.second.pk})
+        self.assertJobState(self.job, progress={"cleared": 1, "skipped_syncing": 2})
+
+        pruned, _ = self.prune()
+        self.assertEqual(pruned, [self.third.pk])
+
+        self.prune()
+        self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE)
+
+        # once its lease is gone, the next run picks the flow back up
         drop_lease(job)
 
-        self.clear().assert_called_once()
-        self.assertTrue(Poll.objects.get(id=self.poll.id).stopped_syncing)
+        pruned, _ = self.prune()
+
+        self.assertEqual(pruned, [self.poll.pk])
+        self.assertEqual(self.stopped(), {self.poll.pk, self.dupe.pk, self.second.pk, self.third.pk})
+
+    def test_steps_over_a_flow_held_by_an_unchunked_pull(self):
+        with held_lock(Poll.POLL_PULL_RESULTS_TASK_LOCK % (self.nigeria.pk, "uuid-1")) as lock:
+            # the lock is never waited on, a chunk holding a job lease can't sit on it for hours
+            pruned, _ = self.prune()
+
+            self.assertEqual(pruned, [self.second.pk])
+            self.assertFalse(Poll.objects.get(id=self.poll.id).stopped_syncing)
+            self.assertJobState(self.job, progress={"cleared": 1, "skipped_syncing": 2})
+
+            # and it is left for whoever holds it, not released from under them
+            self.assertTrue(lock.owned())
+
+    def test_retires_a_flow_before_deleting_its_results(self):
+        stopped_when_deleting = []
+
+        def delete(poll):
+            stopped_when_deleting.append(Poll.objects.get(id=poll.id).stopped_syncing)
+
+        with (
+            patch.object(Poll, "rebuild_poll_results_counts"),
+            patch.object(Poll, "delete_poll_results", autospec=True) as mock_delete,
+        ):
+            mock_delete.side_effect = delete
+
+            run_task(prune_poll_results, self.job.id)
+
+        # a delete interrupted part way must leave a flow that is durably retired, not one
+        # still syncing on results that are half gone
+        self.assertEqual(stopped_when_deleting, [True, True])
+
+    def test_moves_past_a_poll_that_errors(self):
+        def rebuild(poll):
+            if poll.flow_uuid == "uuid-1":
+                raise ValueError("boom")
+
+        with (
+            patch.object(Poll, "rebuild_poll_results_counts", autospec=True) as mock_rebuild,
+            patch.object(Poll, "delete_poll_results", autospec=True) as mock_delete,
+        ):
+            mock_rebuild.side_effect = rebuild
+
+            run_task(prune_poll_results, self.job.id)
+
+        # one broken poll can't stall the polls behind it, and its flow keeps syncing
+        self.assertEqual([call[0][0].pk for call in mock_delete.call_args_list], [self.second.pk])
+        self.assertEqual(self.stopped(), {self.second.pk})
+
+        # a poll failing every run is told apart from one that was merely busy
+        self.assertJobState(self.job, cursor={"after_pk": self.second.pk}, progress={"cleared": 1, "errors": 2})
+
+
+@patch("ureport.polls.sync.POPULATE_BATCH_SIZE", 2)
+@patch("ureport.polls.sync.POPULATE_BATCHES_PER_CHUNK", 2)
+class BackfillAgeGenderTest(PollSyncTestBase):
+    def setUp(self):
+        super(BackfillAgeGenderTest, self).setUp()
+
+        self.polls = [self.poll]
+        for index in range(2, 8):
+            self.polls.append(
+                self.create_poll(self.nigeria, "Poll %d" % index, "uuid-%d" % index, self.education_nigeria, self.admin)
+            )
+
+        self.contacts = [
+            Contact.objects.create(uuid="contact-%d" % index, org=self.nigeria, gender="M", born=1990)
+            for index in range(1, 6)
+        ]
+
+        # another org's contacts belong to that org's job, ids are global but the walk isn't
+        Contact.objects.create(uuid="contact-ug", org=self.uganda, gender="F", born=1985)
+
+        self.job = SyncJob.get_or_create_job(self.nigeria, AGE_GENDER_JOB_TYPE)
+
+        cache.delete(LAST_POPULATED_CONTACT_KEY)
+        self.addCleanup(cache.delete, LAST_POPULATED_CONTACT_KEY)
+
+    def backfill(self, populate=None):
+        with (
+            patch("ureport.utils.populate_age_and_gender_for_contacts") as mock_populate,
+            patch.object(Poll, "rebuild_poll_results_counts", autospec=True) as mock_rebuild,
+        ):
+            if populate:
+                mock_populate.side_effect = populate
+
+            mock_continue = run_task(backfill_age_gender, self.job.id)
+
+        populated = [list(call[0][0]) for call in mock_populate.call_args_list]
+
+        return populated, [call[0][0].pk for call in mock_rebuild.call_args_list], mock_continue
+
+    def contact_ids(self, *indexes):
+        return [self.contacts[index].pk for index in indexes]
+
+    def test_populates_in_batches_then_rebuilds(self):
+        populated, rebuilt, mock_continue = self.backfill()
+
+        # two batches of two contacts, the org's own, and nothing rebuilt yet
+        self.assertEqual(populated, [self.contact_ids(0, 1), self.contact_ids(2, 3)])
+        self.assertEqual(rebuilt, [])
+        mock_continue.assert_called_once_with((self.job.id,), queue="slow", countdown=None)
+
+        self.assertJobState(
+            self.job,
+            cursor={"stage": "populate", "after_contact_id": self.contacts[3].pk},
+            progress={"populated": 4},
+        )
+
+        # the fifth contact is the org's last, so the pass moves on to the rebuild
+        populated, rebuilt, _ = self.backfill()
+
+        self.assertEqual(populated, [self.contact_ids(4)])
+        self.assertEqual(rebuilt, [])
+        self.assertJobState(self.job, cursor={"stage": "rebuild", "populate_watermark": self.contacts[4].pk})
+
+        populated, rebuilt, _ = self.backfill()
+
+        self.assertEqual(populated, [])
+        self.assertEqual(rebuilt, [poll.pk for poll in self.polls[:5]])
+
+        populated, rebuilt, _ = self.backfill()
+        self.assertEqual(rebuilt, [poll.pk for poll in self.polls[5:]])
+
+        populated, rebuilt, mock_continue = self.backfill()
+
+        self.assertEqual(rebuilt, [])
+        mock_continue.assert_not_called()
+
+        job = self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE, progress={"populated": 5, "rebuilt": 7})
+        self.assertEqual(job.cursor["populate_watermark"], self.contacts[4].pk)
+
+    def test_resumes_the_populate_pass_after_a_takeover(self):
+        positions = []
+
+        def populate(contact_ids):
+            job = reload(self.job)
+            positions.append((job.cursor.get("after_contact_id"), job.lease_expires_on))
+
+        self.backfill(populate=populate)
+
+        # each batch checkpoints its position and renews the lease before the next one
+        self.assertEqual([position[0] for position in positions], [0, self.contacts[1].pk])
+        self.assertGreater(positions[1][1], positions[0][1])
+
+        # a worker that dies part way through leaves the position of the batches it finished
+        self.job.force_resync()
+
+        def die(contact_ids):
+            if contact_ids[0] == self.contacts[2].pk:
+                raise ValueError("worker died")
+
+        with self.assertRaises(ValueError):
+            self.backfill(populate=die)
+
+        self.assertJobState(
+            self.job,
+            status=SyncJob.STATUS_FAILED,
+            cursor={"stage": "populate", "after_contact_id": self.contacts[1].pk},
+        )
+
+        # and the walk carries on from there rather than from the org's first contact
+        populated, _, _ = self.backfill()
+        self.assertEqual(populated, [self.contact_ids(2, 3), self.contact_ids(4)])
+
+    def test_resumes_the_rebuild_stage_after_a_kill(self):
+        end_run(
+            self.job,
+            status=SyncJob.STATUS_FAILED,
+            cursor={"stage": "rebuild", "after_pk": self.polls[2].pk},
+            progress={"populated": 5, "rebuilt": 3},
+        )
+
+        populated, rebuilt, _ = self.backfill()
+
+        self.assertEqual(populated, [])
+        self.assertEqual(rebuilt, [poll.pk for poll in self.polls[3:]])
+
+    def test_a_new_run_carries_on_from_the_last_watermark(self):
+        end_run(
+            self.job,
+            cursor={"stage": "rebuild", "after_pk": self.polls[-1].pk, "populate_watermark": self.contacts[2].pk},
+            progress={"populated": 5, "rebuilt": 7},
+            ended_on=timezone.now() - timedelta(days=1),
+        )
+
+        populated, rebuilt, _ = self.backfill()
+
+        # only the contacts added since the last run, and the polls are walked from the start
+        self.assertEqual(populated, [self.contact_ids(3, 4)])
+        self.assertEqual(rebuilt, [])
+
+        populated, _, _ = self.backfill()
+        self.assertEqual(populated, [])
+        self.assertEqual(reload(self.job).cursor["populate_watermark"], self.contacts[4].pk)
+
+    def test_seeds_a_first_run_from_the_unchunked_position(self):
+        cache.set(LAST_POPULATED_CONTACT_KEY, self.contacts[2].pk, None)
+
+        populated, _, _ = self.backfill()
+
+        self.assertEqual(populated, [self.contact_ids(3, 4)])
+
+        # the retired key is only ever read, the job keeps its own position from here
+        self.assertEqual(cache.get(LAST_POPULATED_CONTACT_KEY), self.contacts[2].pk)
+
+
+class MaintenanceDispatchTest(PollSyncTestBase):
+    def counts_nudge(self):
+        with patch.object(rebuild_poll_counts, "apply_async") as mock_queue:
+            rebuild_counts_dispatch()
+
+        return mock_queue
+
+    def prune_nudge(self):
+        with patch.object(prune_poll_results, "apply_async") as mock_queue:
+            queued = prune_results_dispatch()
+
+        return queued, mock_queue
+
+    def test_nudges_the_global_counts_job(self):
+        now = timezone.now()
+
+        self.counts_nudge()
+
+        job = SyncJob.objects.get(job_type=COUNTS_JOB_TYPE)
+        self.assertIsNone(job.org_id)
+        self.assertEqual(job.scope, "")
+
+        # a pass that finished a moment ago isn't started again
+        end_run(job, ended_on=now - timedelta(hours=2))
+        self.counts_nudge().assert_not_called()
+
+        end_run(job, ended_on=now - timedelta(hours=21))
+        self.counts_nudge().assert_called_once_with((job.id,), queue="slow")
+
+        # nor is one still working through its polls, or a paused one
+        SyncJob.objects.filter(id=job.id).update(status=SyncJob.STATUS_RUNNING)
+        hold_lease(job)
+        self.counts_nudge().assert_not_called()
+
+        drop_lease(job)
+        SyncJob.objects.filter(id=job.id).update(status=SyncJob.STATUS_PAUSED)
+        self.counts_nudge().assert_not_called()
+
+        # and a failing streak stretches the wait beyond the daily cadence
+        end_run(job, status=SyncJob.STATUS_FAILED, ended_on=now - timedelta(hours=21), failures=10)
+        self.counts_nudge().assert_not_called()
+
+        end_run(job, status=SyncJob.STATUS_FAILED, ended_on=now - timedelta(days=2), failures=10)
+        self.counts_nudge().assert_called_once()
+
+    def test_measures_the_cadence_from_when_a_run_started(self):
+        now = timezone.now()
+
+        self.counts_nudge()
+        job = SyncJob.objects.get(job_type=COUNTS_JOB_TYPE)
+
+        # a pass that started 19 hours ago is not due again yet, however long it ran for
+        end_run(job, started_on=now - timedelta(hours=19), ended_on=now - timedelta(hours=1))
+        self.counts_nudge().assert_not_called()
+
+        # but a pass that started 21 hours ago is, even though it only ended five hours ago
+        # - measured from the end, a daily job taking hours would drift into two day gaps
+        end_run(job, started_on=now - timedelta(hours=21), ended_on=now - timedelta(hours=5))
+        self.counts_nudge().assert_called_once()
+
+    def complete_prunes(self, ended_on):
+        SyncJob.objects.filter(job_type=PRUNE_JOB_TYPE).update(
+            status=SyncJob.STATUS_COMPLETE, started_on=ended_on, ended_on=ended_on
+        )
+
+    def test_nudges_a_prune_job_per_org(self):
+        now = timezone.now()
+        active_orgs = set(Org.objects.filter(is_active=True).values_list("pk", flat=True))
+
+        queued, mock_queue = self.prune_nudge()
+
+        self.assertEqual(set(queued), active_orgs)
+        self.assertEqual(mock_queue.call_count, len(active_orgs))
+        self.assertEqual(
+            set(SyncJob.objects.filter(job_type=PRUNE_JOB_TYPE).values_list("org_id", flat=True)), active_orgs
+        )
+
+        self.complete_prunes(now - timedelta(hours=2))
+        self.assertEqual(self.prune_nudge()[0], [])
+
+        self.complete_prunes(now - timedelta(hours=21))
+        self.assertEqual(set(self.prune_nudge()[0]), active_orgs)
+
+        # a paused org's prune is left alone, the rest still run
+        SyncJob.objects.filter(job_type=PRUNE_JOB_TYPE, org=self.nigeria).update(status=SyncJob.STATUS_PAUSED)
+        self.assertNotIn(self.nigeria.pk, self.prune_nudge()[0])
+
+    def test_nudges_a_single_org(self):
+        self.assertIn(self.uganda.pk, self.prune_nudge()[0])
+
+        self.complete_prunes(timezone.now() - timedelta(days=1))
+
+        with patch.object(prune_poll_results, "apply_async") as mock_queue:
+            self.assertEqual(prune_results_dispatch(self.nigeria.pk), [self.nigeria.pk])
+
+        job = SyncJob.objects.get(org=self.nigeria, job_type=PRUNE_JOB_TYPE)
+        mock_queue.assert_called_once_with((job.id,), queue="slow")
+
+
+class MaintenanceShimTest(PollSyncTestBase):
+    def test_rebuild_counts_queues_the_global_job(self):
+        with patch.object(rebuild_poll_counts, "apply_async") as mock_queue:
+            rebuild_counts()
+
+        job = SyncJob.objects.get(job_type=COUNTS_JOB_TYPE)
+        self.assertIsNone(job.org_id)
+        mock_queue.assert_called_once_with((job.id,), queue="slow")
+
+    def test_clear_old_poll_results_queues_the_orgs_prune(self):
+        with patch.object(prune_poll_results, "apply_async") as mock_queue:
+            clear_old_poll_results(self.nigeria.pk)
+
+        job = SyncJob.objects.get(org=self.nigeria, job_type=PRUNE_JOB_TYPE)
+        mock_queue.assert_called_once_with((job.id,), queue="slow")
+
+    def test_update_results_age_gender_queues_backfills(self):
+        with patch.object(backfill_age_gender, "apply_async") as mock_queue:
+            update_results_age_gender(self.nigeria.pk)
+
+        job = SyncJob.objects.get(org=self.nigeria, job_type=AGE_GENDER_JOB_TYPE)
+        mock_queue.assert_called_once_with((job.id,), queue="slow")
+
+        # without an org it covers every active one
+        with patch.object(backfill_age_gender, "apply_async") as mock_queue:
+            update_results_age_gender()
+
+        self.assertEqual(mock_queue.call_count, Org.objects.filter(is_active=True).count())
+
+        # an org id that resolves to nothing does nothing, rather than falling back to all
+        with patch.object(backfill_age_gender, "apply_async") as mock_queue:
+            update_results_age_gender(-1)
+
+        mock_queue.assert_not_called()
+
+    def test_shims_record_no_task_state(self):
+        with (
+            patch.object(rebuild_poll_counts, "apply_async"),
+            patch.object(prune_poll_results, "apply_async"),
+            patch.object(backfill_age_gender, "apply_async"),
+        ):
+            rebuild_counts()
+            clear_old_poll_results(self.nigeria.pk)
+            update_results_age_gender()
+
+        # they only enqueue now, so they must not pass themselves off as having run
+        self.assertFalse(TaskState.objects.exists())
 
 
 class SyncStatusTest(PollSyncTestBase):

--- a/ureport/polls/tests.py
+++ b/ureport/polls/tests.py
@@ -28,11 +28,9 @@ from ureport.polls.tasks import (
     pull_refresh,
     pull_results_main_poll,
     pull_results_other_polls,
-    rebuild_counts,
     recheck_poll_flow_data,
     refresh_org_flows,
     update_or_create_questions,
-    update_results_age_gender,
 )
 from ureport.polls.templatetags.ureport import question_segmented_results
 from ureport.stats.models import (
@@ -2449,12 +2447,6 @@ class PollQuestionTest(UreportTest):
             job = SyncJob.objects.get(org=self.poll.org, job_type="poll-results", scope=self.poll.flow_uuid)
             mock_queue_sync.assert_called_once_with((job.id,), queue="sync")
 
-        with patch("ureport.polls.models.Poll.rebuild_poll_results_counts") as mock_rebuild_counts:
-            mock_rebuild_counts.return_value = "Rebuilt"
-
-            rebuild_counts()
-            self.assertEqual(mock_rebuild_counts.call_count, Poll.objects.all().count())
-
         with patch("ureport.polls.models.Poll.update_or_create_questions") as mock_update_or_create_questions:
             mock_update_or_create_questions.side_effect = None
 
@@ -2465,17 +2457,6 @@ class PollQuestionTest(UreportTest):
             poll2 = self.create_poll(self.uganda, "Poll 2", "flow-uuid-2", self.health_uganda, self.admin)
             update_or_create_questions([self.poll.pk, poll2.pk])
             self.assertEqual(mock_update_or_create_questions.call_count, 2)
-
-        with patch("ureport.polls.models.Poll.rebuild_poll_results_counts") as mock_rebuild_counts:
-            mock_rebuild_counts.return_value = "Rebuilt"
-
-            with patch("ureport.polls.tasks.populate_age_and_gender_poll_results") as mock_populate_age_gender_results:
-                mock_populate_age_gender_results.return_value = "Populated"
-
-                update_results_age_gender(self.nigeria.pk)
-
-                mock_populate_age_gender_results.assert_called_once_with(self.nigeria)
-                self.assertEqual(mock_rebuild_counts.call_count, Poll.objects.filter(org=self.nigeria).count())
 
 
 class PollResultsTest(UreportTest):

--- a/ureport/settings_common.py
+++ b/ureport/settings_common.py
@@ -1027,13 +1027,14 @@ CELERY_BEAT_SCHEDULE = {
         "args": ("ureport.stats.tasks.delete_old_contact_activities", "slow"),
     },
     "rebuild-poll-results-count": {
-        "task": "polls.rebuild_counts",
+        "task": "polls.rebuild_counts_dispatch",
         "schedule": crontab(hour=4, minute=0),
+        "options": {"queue": "slow"},
     },
     "clear-old-results": {
-        "task": "dash.orgs.tasks.trigger_org_task",
+        "task": "polls.prune_results_dispatch",
         "schedule": crontab(hour=6, minute=0),
-        "args": ("ureport.polls.tasks.clear_old_poll_results", "slow"),
+        "options": {"queue": "slow"},
     },
     "stats_counts_squash": {
         "task": "stats.stats_counts_squash",

--- a/ureport/utils/__init__.py
+++ b/ureport/utils/__init__.py
@@ -28,6 +28,9 @@ GLOBAL_COUNT_CACHE_KEY = "global_count"
 ORG_CONTACT_COUNT_KEY = "org:%d:contacts-counts"
 ORG_CONTACT_COUNT_TIMEOUT = 3600
 
+# how far the unchunked age and gender walk got, kept only to seed the jobs that replace it
+LAST_POPULATED_CONTACT_KEY = "last-contact-id-populated"
+
 logger = logging.getLogger(__name__)
 
 
@@ -1006,12 +1009,33 @@ def get_segment_org_boundaries(org, segment):
     return location_boundaries
 
 
-def populate_age_and_gender_poll_results(org=None):
+def populate_age_and_gender_for_contacts(contact_ids):
+    """
+    Copies the age and gender of the given contacts onto the poll results they answered.
+    """
     from ureport.contacts.models import Contact
 
-    LAST_POPULATED_CONTACT = "last-contact-id-populated"
+    for contact in Contact.objects.filter(id__in=contact_ids).order_by("id"):
+        update_fields = dict()
+        if contact.born > 0:
+            update_fields["born"] = contact.born
 
-    last_contact_id_populated = cache.get(LAST_POPULATED_CONTACT, 0)
+        if contact.gender != "":
+            update_fields["gender"] = contact.gender
+
+        if update_fields:
+            results_ids = list(PollResult.objects.filter(contact=contact.uuid).values_list("id", flat=True))
+            PollResult.objects.filter(id__in=results_ids).update(**update_fields)
+
+
+def populate_age_and_gender_poll_results(org=None):
+    """
+    Walks contacts in one pass, superseded by the chunked backfill job which resumes rather
+    than starting over when it is interrupted.
+    """
+    from ureport.contacts.models import Contact
+
+    last_contact_id_populated = cache.get(LAST_POPULATED_CONTACT_KEY, 0)
 
     all_contacts = Contact.objects.filter(id__gt=last_contact_id_populated).values_list("id", flat=True).order_by("id")
 
@@ -1025,23 +1049,12 @@ def populate_age_and_gender_poll_results(org=None):
 
     for contact_id_batch in chunk_list(all_contacts, 1000):
         contact_batch = list(contact_id_batch)
-        contacts = Contact.objects.filter(id__in=contact_batch)
-        for contact in contacts:
-            i += 1
 
-            update_fields = dict()
-            if contact.born > 0:
-                update_fields["born"] = contact.born
+        populate_age_and_gender_for_contacts(contact_batch)
+        i += len(contact_batch)
 
-            if contact.gender != "":
-                update_fields["gender"] = contact.gender
-
-            if update_fields:
-                results_ids = list(PollResult.objects.filter(contact=contact.uuid).values_list("id", flat=True))
-                PollResult.objects.filter(id__in=results_ids).update(**update_fields)
-
-            if org is None:
-                cache.set(LAST_POPULATED_CONTACT, contact.pk, None)
+        if org is None:
+            cache.set(LAST_POPULATED_CONTACT_KEY, contact_batch[-1], None)
 
         logger.info(
             "Processed poll results update %d / %d contacts in %ds" % (i, len(all_contacts), time.time() - start)


### PR DESCRIPTION
Converts the poll maintenance family to the resumable chunked sync framework. **Stacks on #1384** (the sync-job plumbing consolidation) — the diff includes its commit until it merges; review only the last commit here.

- **The daily counts rebuild** becomes a single global sync job walking active polls by primary-key keyset, checkpointing and renewing its lease after every poll — retiring the previous global lock with its 4-day timeout. A fresh run restarts the walk; an interrupted one resumes where it stopped.
- **Old-results pruning** becomes a per-org job that retires a flow durably before deleting its results (a crash mid-delete previously could leave half-deleted results still syncing, whose wrong counts would then be rebuilt and frozen), steps over flows that are mid-sync or lock-held without losing its place, distinguishes its skip reasons in progress counters, and revisits skipped flows on the next run.
- **The age/gender backfill** becomes a per-org staged job whose populate stage walks contacts in resumable 1000-id batches — previously an unbounded pass whose interruption discarded everything — and preserves the old incremental semantics by seeding from the legacy global watermark and carrying a per-org watermark between runs. Two deliberate behavior changes, stated in the commit: the no-argument trigger covers active orgs only, and an unknown org id is a no-op instead of an install-wide backfill.
- Legacy task names remain as enqueue-only shims.

As rebased onto #1384, the branch builds entirely on the consolidated framework: shared dispatch cadence/in-flight logic with its backoff expressed as the framework's type, one registry-routed enqueue helper replacing three per-family wrappers, the shared lock context manager in the prune path, checkpoint's task-declared lease default, and `job.new_run` for fresh-run detection — with the run-start cursor reset made durable, so a run that fails before its first checkpoint restarts its walk rather than silently skipping a pass (pinned by test). Its tests use the shared sync-job test helpers.

26 maintenance tests (192 green across polls + utils + syncjobs), pinning per-batch populate resume, lease renewal, cadence boundaries, lost-lease cursor state, first-chunk-failure restarts, the global row's uniqueness, and prune's ordering and lock behavior.