### PR TITLE
Convert the stats tasks to chunked resumable sync jobs

### DIFF
--- a/ureport/settings_common.py
+++ b/ureport/settings_common.py
@@ -1016,15 +1016,17 @@ CELERY_BEAT_SCHEDULE = {
         "relative": True,
         "options": {"queue": "sync"},
     },
-    "refresh-engagement-data": {
-        "task": "dash.orgs.tasks.trigger_org_task",
-        "schedule": crontab(hour=2, minute=0),
-        "args": ("ureport.stats.tasks.refresh_engagement_data", "slow"),
-    },
-    "delete-old-contact-activity": {
-        "task": "dash.orgs.tasks.trigger_org_task",
-        "schedule": crontab(hour=22, minute=0),
-        "args": ("ureport.stats.tasks.delete_old_contact_activities", "slow"),
+    # the stats jobs are due once a day, measured from when each org's last run started
+    # rather than from the clock, so that a long run doesn't push the next one out by its own
+    # duration. The interval is a little under a day so that a run which starts late is still
+    # due the next night. The dispatcher runs through the small hours: the first slot is the
+    # off peak anchor the fixed daily tasks used to have, and the ones after it are same
+    # night retry slots for orgs whose run failed or was interrupted. Running it around the
+    # clock instead would let each org's start time walk backwards into peak hours.
+    "stats-dispatch": {
+        "task": "stats.stats_dispatch",
+        "schedule": crontab(hour=[0, 1, 2, 3, 4], minute=0),
+        "options": {"queue": "slow"},
     },
     "rebuild-poll-results-count": {
         "task": "polls.rebuild_counts",

--- a/ureport/stats/sync.py
+++ b/ureport/stats/sync.py
@@ -1,0 +1,401 @@
+# -*- coding: utf-8 -*-
+
+import logging
+from datetime import timedelta
+
+from django.utils import timezone
+
+from dash.orgs.models import Org, TaskState
+from ureport.celery import app
+from ureport.syncjobs.dispatch import Backoff, enqueue, in_flight, is_due
+from ureport.syncjobs.locks import chunk_lock
+from ureport.syncjobs.models import DEFAULT_LEASE_SECONDS, SyncJob
+from ureport.syncjobs.tasks import JOB_TASKS, chunked_task
+
+logger = logging.getLogger(__name__)
+
+ENGAGEMENT_JOB_TYPE = "engagement-refresh"
+PRUNE_JOB_TYPE = "activities-prune"
+REBUILD_JOB_TYPE = "activities-rebuild"
+
+QUEUE = "slow"
+
+# each of these is a handful of aggregate queries over the org's counters, so a chunk does
+# a few of them rather than the whole product of filters, segments and metrics
+ENGAGEMENT_BATCH_SIZE = 3
+
+# the rebuild's engagement pass only covers one metric, so it can afford wider chunks
+REBUILD_BATCH_SIZE = 5
+REBUILD_METRIC = "active-users"
+
+# a rebuild run recalculates the org's counters first, then refreshes what they feed
+STAGE_ENGAGEMENT = "engagement"
+
+# contact activities are kept for this long, and pruned this many rows at a time
+ACTIVITY_RETENTION = timedelta(days=400)
+PRUNE_BATCH_SIZE = 1000
+PRUNE_BATCHES_PER_CHUNK = 20
+
+# must comfortably exceed the slowest single chunk - a lease that expires mid chunk loses
+# that chunk's work. The rebuild's first chunk is one unbounded pass over the org's
+# activities, so it gets the same headroom as the contact sync's unbounded stages.
+ENGAGEMENT_LEASE_SECONDS = 60 * 30
+PRUNE_LEASE_SECONDS = 60 * 20
+REBUILD_LEASE_SECONDS = 60 * 30
+
+# the counter rebuild replaces every counter an org has and they carry no unique constraint,
+# so two rebuilds running at once leave the org's counts permanently doubled - which the
+# squash task then merges into plausible looking data. The lease alone doesn't prevent that:
+# a redelivered message becomes claimable the moment the lease expires, while the original
+# chunk may still be running. So the recalculation takes a lock whose timeout comfortably
+# outlives both the lease and the broker's redelivery window.
+REBUILD_LOCK_KEY = "rebuild-contacts-activities-counts"
+REBUILD_LOCK_TIMEOUT = REBUILD_LEASE_SECONDS * 4
+
+# how long to wait before trying the recalculation again when another worker holds its lock
+LOCK_BACKOFF = 300
+
+# the task keys the pre-chunking tasks were disabled per org by, honored for the release
+# they still exist in - a chunked job is stopped by pausing it instead
+LEGACY_TASK_KEYS = {
+    ENGAGEMENT_JOB_TYPE: "refresh-engagement-data",
+    PRUNE_JOB_TYPE: "delete-old-contact-activities",
+}
+
+# how often a run of these jobs should start. A little under a day, so that a run which
+# starts late doesn't push the next one out to the following night.
+DAILY_INTERVAL = timedelta(hours=20)
+
+# a failing job backs off exponentially from its normal cadence, so a deterministically
+# broken refresh isn't retried every night forever: 20h, 40h, 80h, 160h, then the cap
+FAILURE_BACKOFF = Backoff(base=DAILY_INTERVAL, cap=timedelta(days=7), max_doublings=4)
+
+
+def engagement_combos():
+    """
+    The engagement data an org's refresh covers, as a deterministic list so that a cursor
+    into it means the same thing to the chunk that resumes from it. A release that changes
+    the metrics or segments changes the list, which is why the cursor carries its length -
+    see _resume_index.
+    """
+    from .models import PollEngagementDailyCount
+
+    return [
+        (time_filter, segment, metric)
+        for time_filter in PollEngagementDailyCount.DATA_TIME_FILTERS
+        for segment in PollEngagementDailyCount.DATA_SEGMENTS
+        for metric in PollEngagementDailyCount.DATA_METRICS
+    ]
+
+
+def rebuild_combos():
+    """
+    The engagement data a counter rebuild invalidates, i.e. every segment and time filter of
+    the metric the contact activity counters feed.
+    """
+    from .models import PollEngagementDailyCount
+
+    return [
+        (time_filter, segment)
+        for time_filter in PollEngagementDailyCount.DATA_TIME_FILTERS
+        for segment in PollEngagementDailyCount.DATA_SEGMENTS
+    ]
+
+
+def finalize_engagement_refresh(job):
+    """
+    Runs once per completed refresh: the average response rate is derived from the same
+    counters, so it is recalculated when they have all been refreshed. Idempotent - it
+    recomputes from the counters and overwrites its cached value.
+    """
+    from .models import PollStatsCounter
+
+    org = job.org
+    if not org:
+        return
+
+    PollStatsCounter.calculate_average_response_rate(org)
+
+
+@chunked_task(
+    ENGAGEMENT_JOB_TYPE,
+    queue=QUEUE,
+    lease_seconds=ENGAGEMENT_LEASE_SECONDS,
+    finalize=finalize_engagement_refresh,
+    name="stats.refresh_engagement",
+)
+def refresh_engagement(job):
+    """
+    Refreshes a batch of one org's engagement data. The cursor is the position reached in
+    the combination list, and is reset by the chunk that finishes it so that the next run
+    starts a fresh pass rather than resuming past the end of the last one.
+    """
+    from .models import PollEngagementDailyCount
+
+    org = job.org
+    if _should_stop(org, job.job_type):
+        return job.abort()
+
+    combos = engagement_combos()
+    index = _resume_index(job.cursor, len(combos))
+    batch = combos[index : index + ENGAGEMENT_BATCH_SIZE]
+
+    for time_filter, segment, metric in batch:
+        PollEngagementDailyCount.refresh_engagement_data(org, metric, segment, time_filter)
+        logger.info(
+            "Refreshed engagement data for org #%d, time_filter - %s, segment - %s, metric - %s",
+            org.id,
+            time_filter,
+            segment,
+            metric,
+        )
+
+    index += len(batch)
+    done = index >= len(combos)
+
+    job.checkpoint(
+        cursor={} if done else {"combo_index": index, "combo_count": len(combos)},
+        progress=job.add_progress(chunks=1, combos=len(batch)),
+    )
+
+    return done
+
+
+@chunked_task(PRUNE_JOB_TYPE, queue=QUEUE, lease_seconds=PRUNE_LEASE_SECONDS, name="stats.prune_contact_activities")
+def prune_contact_activities(job):
+    """
+    Deletes a bounded number of batches of one org's expired contact activities. The
+    deletion is its own resume position - each chunk works on what is still older than the
+    cutoff - so nothing has to be carried in the cursor, and a chunk replayed after a crash
+    simply deletes the next rows rather than the ones already gone.
+    """
+    from .models import ContactActivity
+
+    org = job.org
+    if _should_stop(org, job.job_type):
+        return job.abort()
+
+    # recomputed per chunk rather than frozen for the run - it only ever moves forward, and
+    # a run spanning midnight pruning a few extra hours of activities is harmless
+    cutoff = timezone.now() - ACTIVITY_RETENTION
+
+    deleted = 0
+    exhausted = False
+
+    for _ in range(PRUNE_BATCHES_PER_CHUNK):
+        # unordered - which expired activities go first doesn't matter, and asking for an
+        # order would only cost a sort
+        batch_ids = list(
+            ContactActivity.objects.filter(org=org, date__lte=cutoff).values_list("id", flat=True)[:PRUNE_BATCH_SIZE]
+        )
+        if not batch_ids:
+            exhausted = True
+            break
+
+        ContactActivity.objects.filter(id__in=batch_ids).delete()
+        deleted += len(batch_ids)
+
+    logger.info("Deleted %d contact activities older than %s on org #%d", deleted, cutoff, org.id)
+
+    job.checkpoint(progress=job.add_progress(chunks=1, deleted=deleted))
+
+    return exhausted
+
+
+@chunked_task(
+    REBUILD_JOB_TYPE, queue=QUEUE, lease_seconds=REBUILD_LEASE_SECONDS, name="stats.rebuild_contact_activity_counts"
+)
+def rebuild_contact_activity_counts(job):
+    """
+    Rebuilds one org's contact activity counters, then refreshes the engagement data they
+    feed a batch at a time. The recalculation is a single chunk - it is bounded by the org's
+    activities and rewrites the counters wholesale, so splitting it would leave the counters
+    visibly incomplete between chunks - and it holds a lock while it does, as two of them at
+    once would double the org's counts rather than replace them.
+    """
+    from .models import ContactActivity, PollEngagementDailyCount
+
+    org = job.org
+    if _should_stop(org, job.job_type):
+        return job.abort()
+
+    cursor = dict(job.cursor)
+
+    if not cursor.get("stage"):
+        with _rebuild_lock(org) as acquired:
+            if not acquired:
+                logger.info("Rebuild lock held for org #%d, backing off", org.id)
+                return job.back_off(LOCK_BACKOFF, lock_backoffs=1)
+
+            counters = ContactActivity.recalculate_contact_activity_counts(org)
+
+            job.checkpoint(
+                cursor={"stage": STAGE_ENGAGEMENT, "combo_index": 0, "combo_count": len(rebuild_combos())},
+                progress=job.add_progress(chunks=1, counters=len(counters)),
+            )
+
+        return False
+
+    combos = rebuild_combos()
+    index = _resume_index(cursor, len(combos))
+    batch = combos[index : index + REBUILD_BATCH_SIZE]
+
+    for time_filter, segment in batch:
+        PollEngagementDailyCount.refresh_engagement_data(org, REBUILD_METRIC, segment, time_filter)
+        logger.info(
+            "Refreshed rebuilt engagement data for org #%d, time_filter - %s, segment - %s, metric - %s",
+            org.id,
+            time_filter,
+            segment,
+            REBUILD_METRIC,
+        )
+
+    index += len(batch)
+    done = index >= len(combos)
+
+    job.checkpoint(
+        cursor={} if done else {"stage": STAGE_ENGAGEMENT, "combo_index": index, "combo_count": len(combos)},
+        progress=job.add_progress(chunks=1, combos=len(batch)),
+    )
+
+    return done
+
+
+def _rebuild_lock(org):
+    """
+    Serializes one org's counter recalculation, which two workers at once would double
+    rather than replace - see REBUILD_LOCK_TIMEOUT. Held for the chunk that does the
+    recalculation, not for the whole run.
+    """
+    return chunk_lock(TaskState.get_lock_key(org, REBUILD_LOCK_KEY), REBUILD_LOCK_TIMEOUT)
+
+
+def _should_stop(org, job_type):
+    """
+    Whether the run has nothing left to do for this org: it went away, was deactivated, or
+    had this work disabled. Checked by every chunk rather than only at enqueue, so that a
+    disable lands on the run in flight instead of a dozen continuations later.
+    """
+    return not org or not org.is_active or _is_disabled(org, job_type)
+
+
+def _resume_index(cursor, combo_count):
+    """
+    Where in the combination list a chunk picks up. A bare index means nothing once the list
+    changes under a run - a release that adds or removes a metric would leave the rest of
+    the pass pointing at the wrong combinations, silently skipping a contiguous tail of them
+    - so the length it was taken against is checkpointed with it and a mismatch starts the
+    pass over. One repeated pass is cheaper than stale data nobody notices.
+    """
+    if cursor.get("combo_count") != combo_count:
+        return 0
+
+    return cursor.get("combo_index") or 0
+
+
+def enqueue_org_job(org, job_type):
+    """
+    Ensures this org has a job of the given type and nudges it unless a run is already being
+    worked on. Unlike the dispatcher this ignores the cadence - it is someone asking for a
+    run now. Returns the job id if it was enqueued, None otherwise.
+    """
+    if _is_disabled(org, job_type):
+        logger.info("Job type %s disabled for org #%d, skipping", job_type, org.id)
+        return None
+
+    # a job created here has never been enqueued, which the check below can't tell on its
+    # own - a pending row looks the same whether its message is on the queue or was never sent
+    job, created = SyncJob.objects.get_or_create(org=org, job_type=job_type)
+
+    if not created and (job.status == SyncJob.STATUS_PAUSED or in_flight(job, timezone.now(), include_pending=True)):
+        logger.info("Job #%d (%s) not nudged, %s", job.id, job_type, job.get_status_display())
+        return None
+
+    _enqueue(job)
+    return job.id
+
+
+def dispatch_org_stats(org):
+    """
+    Ensures this org's daily stats jobs exist and nudges the ones that are due. Returns the
+    job types actually enqueued.
+    """
+    now = timezone.now()
+    queued = []
+
+    for job_type in (ENGAGEMENT_JOB_TYPE, PRUNE_JOB_TYPE):
+        if _is_disabled(org, job_type):
+            logger.info("Job type %s disabled for org #%d, skipping", job_type, org.id)
+            continue
+
+        job, created = SyncJob.objects.get_or_create(org=org, job_type=job_type)
+        if not created and not _should_nudge(job, now):
+            continue
+
+        _enqueue(job)
+        queued.append(job_type)
+
+    return queued
+
+
+def _should_nudge(job, now):
+    """
+    Whether the dispatcher queues a chunk of this job: nothing is already working on it or
+    queued for it, and the shared cadence and failure backoff say it is due.
+    """
+    if in_flight(job, now, include_pending=True) or _recently_nudged(job, now):
+        return False
+
+    return is_due(job, now, interval=DAILY_INTERVAL, backoff=FAILURE_BACKOFF)
+
+
+def _recently_nudged(job, now):
+    """
+    Whether the row was touched after its last run ended, which for a job that isn't running
+    means a message was queued for it and hasn't been picked up yet. A job keeps the status
+    of its last run until a worker claims the nudge, so in_flight can't see this one - and
+    without it the dispatcher would queue another message on every pass until one is. The
+    window is the one in_flight allows a running job, so a nudge is trusted for as long as
+    a chunk of this job may take to start moving.
+    """
+    if not job.ended_on or not job.modified_on or job.modified_on <= job.ended_on:
+        return False
+
+    lease_seconds = getattr(JOB_TASKS.get(job.job_type), "lease_seconds", DEFAULT_LEASE_SECONDS)
+
+    return job.modified_on > now - timedelta(seconds=2 * lease_seconds)
+
+
+def _enqueue(job):
+    enqueue(job)
+
+    # nothing writes to the row until a worker claims it, so record the nudge - it is what
+    # tells the next pass that this job already has a message on the queue
+    now = timezone.now()
+    SyncJob.objects.filter(id=job.id).update(modified_on=now)
+    job.modified_on = now
+
+
+def _is_disabled(org, job_type):
+    task_key = LEGACY_TASK_KEYS.get(job_type)
+
+    return bool(task_key) and TaskState.objects.filter(org=org, task_key=task_key, is_disabled=True).exists()
+
+
+@app.task(name="stats.stats_dispatch")
+def stats_dispatch(org_id=None):
+    """
+    Nudges the daily stats jobs that are due. Jobs already being worked on, or already
+    queued, are left alone, so beat can run this on every slot of its nightly window - the
+    first slot starts the orgs that are due and the rest are retry slots for the ones whose
+    run failed or was interrupted.
+    """
+    orgs = Org.objects.filter(is_active=True)
+    if org_id:
+        orgs = orgs.filter(id=org_id)
+
+    for org in orgs:
+        try:
+            dispatch_org_stats(org)
+        except Exception:
+            logger.error("Error dispatching stats jobs for org #%d" % org.pk, exc_info=True)

--- a/ureport/stats/tasks.py
+++ b/ureport/stats/tasks.py
@@ -1,71 +1,46 @@
 import logging
-import time
-from datetime import timedelta
 
 from django_valkey import get_valkey_connection
 
-from django.utils import timezone
-
 from dash.orgs.models import Org
-from dash.orgs.tasks import org_task
 from ureport.celery import app
-from ureport.utils import chunk_list
+
+# the chunked stats tasks live in sync.py - imported here so celery, which only
+# autodiscovers tasks modules, registers them
+from ureport.stats.sync import (  # noqa: F401
+    ENGAGEMENT_JOB_TYPE,
+    PRUNE_JOB_TYPE,
+    REBUILD_JOB_TYPE,
+    enqueue_org_job,
+    prune_contact_activities,
+    rebuild_contact_activity_counts,
+    refresh_engagement,
+    stats_dispatch,
+)
 
 logger = logging.getLogger(__name__)
 
 
-@org_task("refresh-engagement-data", 60 * 60 * 4)
-def refresh_engagement_data(org, since, until):
-    from .models import PollEngagementDailyCount, PollStatsCounter
-
-    start = time.time()
-
-    time_filters = list(PollEngagementDailyCount.DATA_TIME_FILTERS.keys())
-    segments = list(PollEngagementDailyCount.DATA_SEGMENTS.keys())
-    metrics = list(PollEngagementDailyCount.DATA_METRICS.keys())
-
-    for time_filter in time_filters:
-        for segment in segments:
-            for metric in metrics:
-                PollEngagementDailyCount.refresh_engagement_data(org, metric, segment, time_filter)
-                logger.info(
-                    f"Task: refresh_engagement_data org {org.id} in progress for {time.time() - start}s, for time_filter - {time_filter}, segment - {segment}, metric - {metric}"
-                )
-
-    PollStatsCounter.calculate_average_response_rate(org)
-
-    logger.info(f"Task: refresh_engagement_data org {org.id} finished in {time.time() - start}s")
+# ------------------------------------------------------------------------------
+# Shims for the tasks the stats refreshes used to run under. They keep their
+# registered names for one release so queued messages and existing triggers
+# resolve, but only hand the work to the sync jobs - they hold no lock and record
+# no task state.
+# ------------------------------------------------------------------------------
 
 
-@org_task("delete-old-contact-activities", 60 * 60 * 1)
-def delete_old_contact_activities(org, since, until):
-    from .models import ContactActivity
+@app.task(name="ureport.stats.tasks.refresh_engagement_data")
+def refresh_engagement_data(org_id):
+    org = Org.objects.get(pk=org_id)
 
-    now = timezone.now()
-    start_time = time.time()
-    last_used_time = now - timedelta(days=400)
+    return enqueue_org_job(org, ENGAGEMENT_JOB_TYPE)
 
-    # find objects older than 400 days that have used=True so we can update them to used = False
-    old_contact_activities_ids = (
-        ContactActivity.objects.filter(org=org, date__lte=last_used_time).order_by("id").values_list("id", flat=True)
-    )
 
-    org_count = 0
+@app.task(name="ureport.stats.tasks.delete_old_contact_activities")
+def delete_old_contact_activities(org_id):
+    org = Org.objects.get(pk=org_id)
 
-    for batch in chunk_list(old_contact_activities_ids, 1000):
-        batch_ids = list(batch)
-        deleted, old_objects_deleted = ContactActivity.objects.filter(id__in=batch_ids).delete()
-
-        org_count += deleted
-
-        elapsed = time.time() - start_time
-
-        logger.info(f"Task: Deleting {org_count} old contact activities on org #{org.id} in {elapsed:.1f} seconds")
-
-    elapsed = time.time() - start_time
-    logger.info(
-        f"Task: Finished deleting {org_count} old contact activities until {last_used_time} on org #{org.id} in {elapsed:.1f} seconds"
-    )
+    return enqueue_org_job(org, PRUNE_JOB_TYPE)
 
 
 @app.task(name="stats.squash_contact_activities_counts")
@@ -85,33 +60,17 @@ def squash_contact_activities_counts():
 
 
 @app.task(name="stats.rebuild_contacts_activities_counts")
-def rebuild_contacts_activities_counts():
-    from .models import ContactActivity, PollEngagementDailyCount
-
-    time_filters = list(PollEngagementDailyCount.DATA_TIME_FILTERS.keys())
-    segments = list(PollEngagementDailyCount.DATA_SEGMENTS.keys())
-    metric = "active-users"
-
+def rebuild_contacts_activities_counts(org_id=None):
+    """
+    Queues a counter rebuild for every active org, or just the given one. The rebuild itself
+    is now done in resumable chunks by stats.rebuild_contact_activity_counts.
+    """
     orgs = Org.objects.filter(is_active=True)
+    if org_id:
+        orgs = orgs.filter(id=org_id)
+
     for org in orgs:
-        start_rebuild = time.time()
-
-        ContactActivity.recalculate_contact_activity_counts(org)
-        logger.info(
-            f"Task: rebuild_contacts_activities_counts finished recalculating contact activity counts for org {org.id} in {time.time() - start_rebuild}s"
-        )
-
-        start_refresh = time.time()
-
-        for time_filter in time_filters:
-            for segment in segments:
-                PollEngagementDailyCount.refresh_engagement_data(org, metric, segment, time_filter)
-                logger.info(
-                    f"Task: rebuild_contacts_activities_counts refreshing contacts activities engagement stats for org {org.id} in progress for {time.time() - start_refresh}s, for time_filter - {time_filter}, segment - {segment}, metric - {metric}"
-                )
-        logger.info(
-            f"Task: rebuild_contacts_activities_counts finished recalculating contact activity and refreshing contacts activities engagement stats for org {org.id} in {time.time() - start_rebuild}s"
-        )
+        enqueue_org_job(org, REBUILD_JOB_TYPE)
 
 
 @app.task(name="stats.stats_counts_squash")

--- a/ureport/stats/test_sync.py
+++ b/ureport/stats/test_sync.py
@@ -1,0 +1,682 @@
+# -*- coding: utf-8 -*-
+
+from datetime import timedelta
+from unittest.mock import call, patch
+
+from django.conf import settings
+from django.utils import timezone
+
+from dash.orgs.models import TaskState
+from ureport.stats.models import ContactActivity
+from ureport.stats.sync import (
+    DAILY_INTERVAL,
+    ENGAGEMENT_BATCH_SIZE,
+    ENGAGEMENT_JOB_TYPE,
+    LOCK_BACKOFF,
+    PRUNE_JOB_TYPE,
+    REBUILD_BATCH_SIZE,
+    REBUILD_JOB_TYPE,
+    REBUILD_LOCK_KEY,
+    REBUILD_METRIC,
+    engagement_combos,
+    finalize_engagement_refresh,
+    prune_contact_activities,
+    rebuild_combos,
+    rebuild_contact_activity_counts,
+    refresh_engagement,
+    stats_dispatch,
+)
+from ureport.stats.tasks import (
+    delete_old_contact_activities,
+    rebuild_contacts_activities_counts,
+    refresh_engagement_data,
+)
+from ureport.syncjobs.models import ABORTED, SyncJob
+from ureport.syncjobs.testing import SyncJobTestMixin, end_run, held_lock, make_stale, reload, run_task
+from ureport.tests import UreportTest
+
+REFRESH_ENGAGEMENT_DATA = "ureport.stats.models.PollEngagementDailyCount.refresh_engagement_data"
+CALCULATE_RESPONSE_RATE = "ureport.stats.models.PollStatsCounter.calculate_average_response_rate"
+RECALCULATE_COUNTS = "ureport.stats.models.ContactActivity.recalculate_contact_activity_counts"
+
+
+class RefreshEngagementTest(SyncJobTestMixin, UreportTest):
+    def setUp(self):
+        super().setUp()
+
+        self.job = SyncJob.get_or_create_job(self.nigeria, ENGAGEMENT_JOB_TYPE)
+
+        self.mock_refresh = self.start_patch(patch(REFRESH_ENGAGEMENT_DATA))
+        self.mock_response_rate = self.start_patch(patch(CALCULATE_RESPONSE_RATE))
+
+    def test_combos_refreshed_a_batch_at_a_time(self):
+        combos = engagement_combos()
+        self.assertEqual(len(combos), 60)
+
+        mock_continue = run_task(refresh_engagement, self.job.id)
+
+        self.assertJobState(
+            self.job,
+            status=SyncJob.STATUS_RUNNING,
+            cursor={"combo_index": ENGAGEMENT_BATCH_SIZE, "combo_count": len(combos)},
+            progress={"chunks": 1, "combos": ENGAGEMENT_BATCH_SIZE},
+        )
+        mock_continue.assert_called_once_with((self.job.id,), queue="slow", countdown=None)
+
+        # the metric leads the call, the cursor position doesn't
+        self.assertEqual(
+            self.mock_refresh.call_args_list,
+            [call(self.nigeria, metric, segment, time_filter) for time_filter, segment, metric in combos[:3]],
+        )
+
+        # the response rate is only derived once the whole product has been refreshed
+        self.mock_response_rate.assert_not_called()
+
+        chunks_left = len(combos) // ENGAGEMENT_BATCH_SIZE - 1
+        run_task(refresh_engagement, self.job.id, times=chunks_left)
+
+        # the finished run leaves nothing to resume from, so the next run refreshes it all again
+        self.assertJobState(
+            self.job,
+            status=SyncJob.STATUS_COMPLETE,
+            progress={"chunks": chunks_left + 1, "combos": len(combos)},
+            cursor={},
+            needs_finalize=False,
+        )
+        self.assertEqual(self.mock_refresh.call_count, len(combos))
+        self.mock_response_rate.assert_called_once_with(self.nigeria)
+
+        run_task(refresh_engagement, self.job.id)
+
+        self.assertJobState(self.job, cursor={"combo_index": ENGAGEMENT_BATCH_SIZE, "combo_count": len(combos)})
+        self.assertEqual(self.mock_refresh.call_args_list[-3:], self.mock_refresh.call_args_list[:3])
+
+    def test_resumes_mid_list(self):
+        combos = engagement_combos()
+        SyncJob.objects.filter(id=self.job.id).update(
+            cursor={"combo_index": len(combos) - 2, "combo_count": len(combos)}
+        )
+
+        run_task(refresh_engagement, self.job.id)
+
+        self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE, cursor={}, progress={"chunks": 1, "combos": 2})
+        self.assertEqual(
+            self.mock_refresh.call_args_list,
+            [call(self.nigeria, metric, segment, time_filter) for time_filter, segment, metric in combos[-2:]],
+        )
+
+    def test_cursor_past_the_end_completes(self):
+        combos = engagement_combos()
+        SyncJob.objects.filter(id=self.job.id).update(cursor={"combo_index": 500, "combo_count": len(combos)})
+
+        run_task(refresh_engagement, self.job.id)
+
+        self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE, cursor={})
+        self.mock_refresh.assert_not_called()
+
+    def test_changed_combo_list_restarts_the_pass(self):
+        # a release that adds or drops a metric or segment leaves the position pointing at
+        # different combinations than it was taken against
+        run_task(refresh_engagement, self.job.id, times=2)
+        shorter = engagement_combos()[:30]
+
+        with patch("ureport.stats.sync.engagement_combos", return_value=shorter):
+            run_task(refresh_engagement, self.job.id)
+
+        self.assertJobState(self.job, cursor={"combo_index": ENGAGEMENT_BATCH_SIZE, "combo_count": len(shorter)})
+
+        # the pass starts over rather than skipping the tail the stale position would miss
+        self.assertEqual(self.mock_refresh.call_args_list[6:], self.mock_refresh.call_args_list[:3])
+
+    def test_failed_chunk_resumes_from_its_last_position(self):
+        combos = engagement_combos()
+        run_task(refresh_engagement, self.job.id, times=2)
+        self.mock_refresh.side_effect = ValueError("boom")
+
+        with self.assertRaises(ValueError):
+            run_task(refresh_engagement, self.job.id)
+
+        self.assertJobState(
+            self.job,
+            status=SyncJob.STATUS_FAILED,
+            consecutive_failures=1,
+            cursor={"combo_index": 2 * ENGAGEMENT_BATCH_SIZE, "combo_count": len(combos)},
+        )
+
+        self.mock_refresh.side_effect = None
+        run_task(refresh_engagement, self.job.id)
+
+        self.assertJobState(self.job, cursor={"combo_index": 3 * ENGAGEMENT_BATCH_SIZE, "combo_count": len(combos)})
+
+    def test_deactivated_org_aborts_the_run(self):
+        run_task(refresh_engagement, self.job.id)
+
+        self.nigeria.is_active = False
+        self.nigeria.save(update_fields=("is_active",))
+
+        run_task(refresh_engagement, self.job.id)
+
+        job = self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE, cursor={})
+        self.assertEqual(job.progress[ABORTED], 1)
+        self.assertEqual(self.mock_refresh.call_count, ENGAGEMENT_BATCH_SIZE)
+
+        # a run that refreshed only part of the data doesn't get to publish a response rate
+        self.mock_response_rate.assert_not_called()
+
+    def test_disabling_the_refresh_mid_run_aborts_it(self):
+        run_task(refresh_engagement, self.job.id)
+
+        TaskState.objects.create(org=self.nigeria, task_key="refresh-engagement-data", is_disabled=True)
+
+        # the kill switch lands on the run in flight, not just on the next enqueue
+        run_task(refresh_engagement, self.job.id)
+
+        job = self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE, cursor={})
+        self.assertEqual(job.progress[ABORTED], 1)
+        self.assertEqual(self.mock_refresh.call_count, ENGAGEMENT_BATCH_SIZE)
+        self.mock_response_rate.assert_not_called()
+
+    def test_finalize_is_idempotent(self):
+        job = reload(self.job)
+
+        finalize_engagement_refresh(job)
+        finalize_engagement_refresh(job)
+
+        self.assertEqual(self.mock_response_rate.call_args_list, [call(self.nigeria), call(self.nigeria)])
+
+
+class PruneContactActivitiesTest(SyncJobTestMixin, UreportTest):
+    def setUp(self):
+        super().setUp()
+
+        self.job = SyncJob.get_or_create_job(self.nigeria, PRUNE_JOB_TYPE)
+
+    def _create_activities(self, org, count, days_old):
+        date = (timezone.now() - timedelta(days=days_old)).date()
+        return ContactActivity.objects.bulk_create(
+            [ContactActivity(org=org, contact=f"contact-{days_old}-{i}", date=date) for i in range(count)]
+        )
+
+    def test_prunes_until_nothing_is_left(self):
+        self._create_activities(self.nigeria, 5, days_old=401)
+        self._create_activities(self.nigeria, 2, days_old=10)
+        self._create_activities(self.uganda, 3, days_old=401)
+
+        with patch("ureport.stats.sync.PRUNE_BATCH_SIZE", 2), patch("ureport.stats.sync.PRUNE_BATCHES_PER_CHUNK", 2):
+            mock_continue = run_task(prune_contact_activities, self.job.id)
+
+            self.assertJobState(self.job, status=SyncJob.STATUS_RUNNING, progress={"chunks": 1, "deleted": 4})
+            mock_continue.assert_called_once_with((self.job.id,), queue="slow", countdown=None)
+
+            # the chunk that runs out of expired activities is the one that finishes the run
+            run_task(prune_contact_activities, self.job.id)
+
+        self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE, progress={"chunks": 2, "deleted": 5})
+
+        # only the expired activities of this org went
+        self.assertEqual(ContactActivity.objects.filter(org=self.nigeria).count(), 2)
+        self.assertEqual(ContactActivity.objects.filter(org=self.uganda).count(), 3)
+
+    def test_run_with_nothing_to_prune_completes(self):
+        self._create_activities(self.nigeria, 2, days_old=10)
+
+        mock_continue = run_task(prune_contact_activities, self.job.id)
+
+        self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE, progress={"chunks": 1, "deleted": 0}, cursor={})
+        mock_continue.assert_not_called()
+
+        # and re-running is harmless - the deletion is its own resume position
+        run_task(prune_contact_activities, self.job.id)
+
+        self.assertJobState(self.job, progress={"chunks": 1, "deleted": 0})
+        self.assertEqual(ContactActivity.objects.filter(org=self.nigeria).count(), 2)
+
+    def test_deactivated_org_aborts_the_run(self):
+        self._create_activities(self.nigeria, 2, days_old=401)
+        self.nigeria.is_active = False
+        self.nigeria.save(update_fields=("is_active",))
+
+        run_task(prune_contact_activities, self.job.id)
+
+        job = self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE)
+        self.assertEqual(job.progress[ABORTED], 1)
+        self.assertEqual(ContactActivity.objects.filter(org=self.nigeria).count(), 2)
+
+    def test_disabling_the_prune_mid_run_aborts_it(self):
+        self._create_activities(self.nigeria, 4, days_old=401)
+
+        with patch("ureport.stats.sync.PRUNE_BATCH_SIZE", 1), patch("ureport.stats.sync.PRUNE_BATCHES_PER_CHUNK", 1):
+            run_task(prune_contact_activities, self.job.id)
+
+            TaskState.objects.create(org=self.nigeria, task_key="delete-old-contact-activities", is_disabled=True)
+
+            run_task(prune_contact_activities, self.job.id)
+
+        job = self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE)
+        self.assertEqual(job.progress[ABORTED], 1)
+        self.assertEqual(ContactActivity.objects.filter(org=self.nigeria).count(), 3)
+
+
+class RebuildContactActivityCountsTest(SyncJobTestMixin, UreportTest):
+    def setUp(self):
+        super().setUp()
+
+        self.job = SyncJob.get_or_create_job(self.nigeria, REBUILD_JOB_TYPE)
+
+        self.mock_refresh = self.start_patch(patch(REFRESH_ENGAGEMENT_DATA))
+
+    @patch(RECALCULATE_COUNTS)
+    def test_counters_are_rebuilt_before_what_they_feed(self, mock_recalculate):
+        mock_recalculate.return_value = {("a",): 1, ("b",): 2}
+        combos = rebuild_combos()
+        self.assertEqual(len(combos), 15)
+
+        # the counter rebuild is a chunk of its own
+        mock_continue = run_task(rebuild_contact_activity_counts, self.job.id)
+
+        self.assertJobState(
+            self.job,
+            cursor={"stage": "engagement", "combo_index": 0, "combo_count": len(combos)},
+            progress={"chunks": 1, "counters": 2},
+        )
+        mock_recalculate.assert_called_once_with(self.nigeria)
+        self.mock_refresh.assert_not_called()
+        mock_continue.assert_called_once_with((self.job.id,), queue="slow", countdown=None)
+
+        # then the engagement data it feeds, a batch at a time
+        run_task(rebuild_contact_activity_counts, self.job.id)
+
+        self.assertJobState(
+            self.job,
+            cursor={"stage": "engagement", "combo_index": REBUILD_BATCH_SIZE, "combo_count": len(combos)},
+            progress={"chunks": 2, "counters": 2, "combos": REBUILD_BATCH_SIZE},
+        )
+        self.assertEqual(
+            self.mock_refresh.call_args_list,
+            [call(self.nigeria, REBUILD_METRIC, segment, time_filter) for time_filter, segment in combos[:5]],
+        )
+
+        run_task(rebuild_contact_activity_counts, self.job.id, times=len(combos) // REBUILD_BATCH_SIZE - 1)
+
+        self.assertJobState(
+            self.job,
+            status=SyncJob.STATUS_COMPLETE,
+            cursor={},
+            progress={"chunks": 4, "counters": 2, "combos": len(combos)},
+        )
+        self.assertEqual(self.mock_refresh.call_count, len(combos))
+
+        # the counters are only recalculated once per run, and a new run starts over
+        self.assertEqual(mock_recalculate.call_count, 1)
+
+        run_task(rebuild_contact_activity_counts, self.job.id)
+
+        self.assertEqual(mock_recalculate.call_count, 2)
+        self.assertJobState(self.job, cursor={"stage": "engagement", "combo_index": 0, "combo_count": len(combos)})
+
+    @patch(RECALCULATE_COUNTS)
+    def test_backs_off_while_another_worker_rebuilds(self, mock_recalculate):
+        # two recalculations at once would double the org's counters rather than replace
+        # them, so a chunk that can't have the lock waits instead of running anyway
+        with held_lock(TaskState.get_lock_key(self.nigeria, REBUILD_LOCK_KEY)):
+            mock_continue = run_task(rebuild_contact_activity_counts, self.job.id)
+
+        mock_recalculate.assert_not_called()
+        mock_continue.assert_called_once_with((self.job.id,), queue="slow", countdown=LOCK_BACKOFF)
+
+        self.assertJobState(self.job, status=SyncJob.STATUS_RUNNING, cursor={}, progress={"lock_backoffs": 1})
+
+        # and picks the rebuild up once the lock is free again
+        run_task(rebuild_contact_activity_counts, self.job.id)
+
+        mock_recalculate.assert_called_once_with(self.nigeria)
+        self.assertEqual(reload(self.job).cursor["stage"], "engagement")
+
+    def test_rebuild_recalculates_the_orgs_counters(self):
+        ContactActivity.objects.create(
+            org=self.nigeria, contact="contact-1", date=timezone.now().date(), gender="M", born=1990
+        )
+
+        run_task(rebuild_contact_activity_counts, self.job.id)
+
+        self.assertJobState(self.job, progress={"chunks": 1, "counters": 3})
+
+    @patch(RECALCULATE_COUNTS)
+    def test_deactivated_org_aborts_the_run(self, mock_recalculate):
+        self.nigeria.is_active = False
+        self.nigeria.save(update_fields=("is_active",))
+
+        run_task(rebuild_contact_activity_counts, self.job.id)
+
+        job = self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE)
+        self.assertEqual(job.progress[ABORTED], 1)
+        mock_recalculate.assert_not_called()
+
+
+class DispatchTest(SyncJobTestMixin, UreportTest):
+    def setUp(self):
+        super().setUp()
+
+        self.uganda.is_active = False
+        self.uganda.save(update_fields=("is_active",))
+
+    def _dispatch(self):
+        with (
+            patch.object(refresh_engagement, "apply_async") as mock_engagement,
+            patch.object(prune_contact_activities, "apply_async") as mock_prune,
+        ):
+            stats_dispatch()
+
+        return mock_engagement, mock_prune
+
+    def _job(self, job_type):
+        return SyncJob.objects.get(org=self.nigeria, job_type=job_type)
+
+    def _end_run(self, job, ago, ran_for=timedelta(0), failures=0):
+        """
+        Leaves the job as a whole run - started and ended - that finished that long ago,
+        which is the state the cadence and the failure backoff are read from. modified_on
+        is moved back with it so the run doesn't also look freshly nudged.
+        """
+        ended_on = timezone.now() - ago
+
+        return end_run(
+            job,
+            status=SyncJob.STATUS_FAILED if failures else SyncJob.STATUS_COMPLETE,
+            started_on=ended_on - ran_for,
+            ended_on=ended_on,
+            failures=failures,
+            lease_owner=None,
+            lease_expires_on=None,
+            modified_on=ended_on,
+        )
+
+    def test_creates_and_enqueues_a_job_of_each_type_per_active_org(self):
+        self.uganda.is_active = True
+        self.uganda.save(update_fields=("is_active",))
+
+        mock_engagement, mock_prune = self._dispatch()
+
+        jobs = SyncJob.objects.filter(job_type__in=(ENGAGEMENT_JOB_TYPE, PRUNE_JOB_TYPE))
+        self.assertEqual(
+            {(job.org.subdomain, job.job_type) for job in jobs},
+            {
+                ("nigeria", ENGAGEMENT_JOB_TYPE),
+                ("nigeria", PRUNE_JOB_TYPE),
+                ("uganda", ENGAGEMENT_JOB_TYPE),
+                ("uganda", PRUNE_JOB_TYPE),
+            },
+        )
+        self.assertEqual(mock_engagement.call_count, 2)
+        self.assertEqual(mock_prune.call_count, 2)
+
+        # dispatching again reuses the same jobs
+        self._dispatch()
+
+        self.assertEqual(SyncJob.objects.filter(job_type__in=(ENGAGEMENT_JOB_TYPE, PRUNE_JOB_TYPE)).count(), 4)
+
+    def test_pending_jobs_are_only_enqueued_once(self):
+        mock_engagement, mock_prune = self._dispatch()
+
+        self.assertEqual(mock_engagement.call_count, 1)
+        self.assertEqual(mock_prune.call_count, 1)
+
+        # the messages are queued but nothing has claimed them yet, so the jobs are still
+        # pending - nudging them again would only duplicate the messages, and a surplus one
+        # landing after the run completes starts a whole fresh pass
+        engagement = self._job(ENGAGEMENT_JOB_TYPE)
+        self.assertEqual(engagement.status, SyncJob.STATUS_PENDING)
+
+        mock_engagement, mock_prune = self._dispatch()
+
+        mock_engagement.assert_not_called()
+        mock_prune.assert_not_called()
+
+        # a message the broker genuinely lost is picked back up once nothing has moved for
+        # long enough
+        make_stale(engagement, seconds_ago=2 * 60 * 60)
+
+        mock_engagement, _ = self._dispatch()
+
+        mock_engagement.assert_called_once_with((engagement.id,), queue="slow")
+
+    def test_a_due_job_is_only_enqueued_once(self):
+        self._dispatch()
+        engagement = self._job(ENGAGEMENT_JOB_TYPE)
+
+        self._end_run(engagement, ago=DAILY_INTERVAL + timedelta(hours=1))
+
+        mock_engagement, _ = self._dispatch()
+        mock_engagement.assert_called_once_with((engagement.id,), queue="slow")
+
+        # the run it queued hasn't been picked up yet, so the job still looks finished and
+        # stale - the nudge is what stops the next pass queueing a second one
+        mock_engagement, _ = self._dispatch()
+        mock_engagement.assert_not_called()
+
+        # unless nothing came of it, in which case it is queued afresh
+        make_stale(engagement, seconds_ago=2 * 60 * 60)
+
+        mock_engagement, _ = self._dispatch()
+        mock_engagement.assert_called_once_with((engagement.id,), queue="slow")
+
+    def test_an_explicit_trigger_defers_only_to_a_run_in_flight(self):
+        self._dispatch()
+        engagement = self._job(ENGAGEMENT_JOB_TYPE)
+        self._end_run(engagement, ago=timedelta(minutes=5))
+
+        # the cadence and the nudge are the dispatcher's business - asking for a refresh
+        # directly gets one, as long as no run is actually being worked on
+        with patch.object(refresh_engagement, "apply_async") as mock_enqueue:
+            refresh_engagement_data(self.nigeria.id)
+            refresh_engagement_data(self.nigeria.id)
+
+        self.assertEqual(mock_enqueue.call_count, 2)
+
+    def test_only_due_once_a_day(self):
+        self._dispatch()
+
+        engagement = self._job(ENGAGEMENT_JOB_TYPE)
+        prune = self._job(PRUNE_JOB_TYPE)
+
+        self._end_run(engagement, ago=DAILY_INTERVAL - timedelta(hours=1))
+        self._end_run(prune, ago=DAILY_INTERVAL + timedelta(hours=1))
+
+        mock_engagement, mock_prune = self._dispatch()
+
+        mock_engagement.assert_not_called()
+        mock_prune.assert_called_once_with((prune.id,), queue="slow")
+
+        # once the engagement run is stale enough too it goes again
+        self._end_run(engagement, ago=DAILY_INTERVAL + timedelta(minutes=1))
+
+        mock_engagement, _ = self._dispatch()
+
+        mock_engagement.assert_called_once_with((engagement.id,), queue="slow")
+
+    def test_cadence_is_measured_from_when_the_run_started(self):
+        self._dispatch()
+        engagement = self._job(ENGAGEMENT_JOB_TYPE)
+
+        # the cadence is how often a run should start, so a long run doesn't push the next
+        # one out by its own duration - this one ended an hour ago but started a day before
+        self._end_run(engagement, ago=timedelta(hours=1), ran_for=DAILY_INTERVAL)
+
+        mock_engagement, _ = self._dispatch()
+
+        mock_engagement.assert_called_once_with((engagement.id,), queue="slow")
+
+    def test_failures_back_off_beyond_the_daily_cadence(self):
+        self._dispatch()
+        engagement = self._job(ENGAGEMENT_JOB_TYPE)
+
+        # a single failure is retried at the normal cadence
+        self._end_run(engagement, ago=DAILY_INTERVAL + timedelta(hours=1), failures=1)
+        mock_engagement, _ = self._dispatch()
+        mock_engagement.assert_called_once_with((engagement.id,), queue="slow")
+
+        # a streak of them earns a wait longer than a night: 20h, 40h, 80h, 160h
+        self._end_run(engagement, ago=timedelta(hours=25), failures=3)
+        mock_engagement, _ = self._dispatch()
+        mock_engagement.assert_not_called()
+
+        self._end_run(engagement, ago=timedelta(hours=81), failures=3)
+        mock_engagement, _ = self._dispatch()
+        mock_engagement.assert_called_once_with((engagement.id,), queue="slow")
+
+        # but never longer than the cap
+        self._end_run(engagement, ago=timedelta(days=6), failures=50)
+        mock_engagement, _ = self._dispatch()
+        mock_engagement.assert_not_called()
+
+        self._end_run(engagement, ago=timedelta(days=8), failures=50)
+        mock_engagement, _ = self._dispatch()
+        mock_engagement.assert_called_once_with((engagement.id,), queue="slow")
+
+    def test_a_failure_backoff_is_measured_from_when_the_run_failed(self):
+        self._dispatch()
+        engagement = self._job(ENGAGEMENT_JOB_TYPE)
+
+        # unlike the cadence, the backoff is a wait after the failure - a run that took a
+        # day to fail doesn't get retried the moment it does
+        self._end_run(engagement, ago=timedelta(hours=1), ran_for=DAILY_INTERVAL, failures=1)
+
+        mock_engagement, _ = self._dispatch()
+
+        mock_engagement.assert_not_called()
+
+    def test_skips_paused_jobs(self):
+        self._dispatch()
+        engagement = self._job(ENGAGEMENT_JOB_TYPE)
+        self.assertTrue(engagement.pause())
+
+        mock_engagement, _ = self._dispatch()
+
+        mock_engagement.assert_not_called()
+
+    def test_skips_job_types_disabled_for_the_org(self):
+        TaskState.objects.create(org=self.nigeria, task_key="refresh-engagement-data", is_disabled=True)
+
+        mock_engagement, mock_prune = self._dispatch()
+
+        # the kill switch the pre-chunking task honored keeps the job from even existing
+        self.assertFalse(SyncJob.objects.filter(org=self.nigeria, job_type=ENGAGEMENT_JOB_TYPE).exists())
+        mock_engagement.assert_not_called()
+        mock_prune.assert_called_once()
+
+    def test_leaves_a_run_in_flight_alone(self):
+        self._dispatch()
+        engagement = self._job(ENGAGEMENT_JOB_TYPE)
+        engagement.claim("worker-1", lease_seconds=600)
+
+        # under a live lease - a chunk is being worked on
+        mock_engagement, _ = self._dispatch()
+        mock_engagement.assert_not_called()
+
+        # and between chunks, where the lease is released but a continuation is on its way
+        engagement.checkpoint(cursor={"combo_index": 3})
+        engagement.release_lease()
+
+        mock_engagement, _ = self._dispatch()
+        mock_engagement.assert_not_called()
+
+        # a run that stopped checkpointing entirely lost its continuation, so nudge it
+        make_stale(engagement, seconds_ago=2 * 60 * 60)
+
+        mock_engagement, _ = self._dispatch()
+        mock_engagement.assert_called_once_with((engagement.id,), queue="slow")
+
+    def test_errors_are_isolated_per_org(self):
+        self.uganda.is_active = True
+        self.uganda.save(update_fields=("is_active",))
+
+        with (
+            patch("ureport.stats.sync.dispatch_org_stats", side_effect=[ValueError("boom"), None]) as mock_dispatch,
+            patch("ureport.stats.sync.logger") as mock_logger,
+        ):
+            stats_dispatch()
+
+        self.assertEqual(mock_dispatch.call_count, 2)
+        self.assertEqual(mock_logger.error.call_count, 1)
+
+    def test_can_be_limited_to_one_org(self):
+        self.uganda.is_active = True
+        self.uganda.save(update_fields=("is_active",))
+
+        with patch.object(refresh_engagement, "apply_async"), patch.object(prune_contact_activities, "apply_async"):
+            stats_dispatch(org_id=self.nigeria.id)
+
+        self.assertEqual(
+            set(SyncJob.objects.values_list("org__subdomain", flat=True).distinct()),
+            {"nigeria"},
+        )
+
+    def test_beat_runs_the_dispatcher(self):
+        # nothing else nudges these jobs, so a beat entry pointing at a name that no longer
+        # exists would simply stop the stats refreshing
+        entry = settings.CELERY_BEAT_SCHEDULE["stats-dispatch"]
+        self.assertEqual(entry["task"], stats_dispatch.name)
+        self.assertEqual(entry["options"], {"queue": "slow"})
+
+
+class ShimsTest(SyncJobTestMixin, UreportTest):
+    def test_registered_task_names(self):
+        # the names messages already on the queue and existing triggers resolve by - renaming
+        # any of these silently drops that work on the floor
+        self.assertEqual(refresh_engagement_data.name, "ureport.stats.tasks.refresh_engagement_data")
+        self.assertEqual(delete_old_contact_activities.name, "ureport.stats.tasks.delete_old_contact_activities")
+        self.assertEqual(rebuild_contacts_activities_counts.name, "stats.rebuild_contacts_activities_counts")
+
+    def test_refresh_engagement_data_enqueues_a_job(self):
+        with patch.object(refresh_engagement, "apply_async") as mock_enqueue:
+            result = refresh_engagement_data(self.nigeria.id)
+
+        job = SyncJob.objects.get(org=self.nigeria, job_type=ENGAGEMENT_JOB_TYPE)
+        self.assertEqual(result, job.id)
+        mock_enqueue.assert_called_once_with((job.id,), queue="slow")
+
+        # it neither runs nor claims the work, so it must not report on it either
+        self.assertFalse(TaskState.objects.filter(org=self.nigeria).exists())
+
+        # and it leaves a run that is already being worked on alone
+        job.claim("worker-1", lease_seconds=600)
+
+        with patch.object(refresh_engagement, "apply_async") as mock_enqueue:
+            self.assertIsNone(refresh_engagement_data(self.nigeria.id))
+
+        mock_enqueue.assert_not_called()
+
+    def test_delete_old_contact_activities_enqueues_a_job(self):
+        with patch.object(prune_contact_activities, "apply_async") as mock_enqueue:
+            result = delete_old_contact_activities(self.nigeria.id)
+
+        job = SyncJob.objects.get(org=self.nigeria, job_type=PRUNE_JOB_TYPE)
+        self.assertEqual(result, job.id)
+        mock_enqueue.assert_called_once_with((job.id,), queue="slow")
+        self.assertFalse(TaskState.objects.filter(org=self.nigeria).exists())
+
+    def test_shims_honor_the_orgs_kill_switch(self):
+        TaskState.objects.create(org=self.nigeria, task_key="delete-old-contact-activities", is_disabled=True)
+
+        with patch.object(prune_contact_activities, "apply_async") as mock_enqueue:
+            self.assertIsNone(delete_old_contact_activities(self.nigeria.id))
+
+        mock_enqueue.assert_not_called()
+        self.assertFalse(SyncJob.objects.filter(org=self.nigeria, job_type=PRUNE_JOB_TYPE).exists())
+
+    def test_rebuild_contacts_activities_counts_enqueues_every_active_org(self):
+        with patch.object(rebuild_contact_activity_counts, "apply_async") as mock_enqueue:
+            rebuild_contacts_activities_counts()
+
+        jobs = SyncJob.objects.filter(job_type=REBUILD_JOB_TYPE)
+        self.assertEqual({job.org.subdomain for job in jobs}, {"nigeria", "uganda"})
+        self.assertEqual({call_args[0][0][0] for call_args in mock_enqueue.call_args_list}, {job.id for job in jobs})
+        self.assertFalse(TaskState.objects.exists())
+
+    def test_rebuild_contacts_activities_counts_can_be_limited_to_one_org(self):
+        with patch.object(rebuild_contact_activity_counts, "apply_async") as mock_enqueue:
+            rebuild_contacts_activities_counts(org_id=self.nigeria.id)
+
+        job = SyncJob.objects.get(job_type=REBUILD_JOB_TYPE)
+        self.assertEqual(job.org, self.nigeria)
+        mock_enqueue.assert_called_once_with((job.id,), queue="slow")


### PR DESCRIPTION
Converts the stats task family to the resumable chunked sync framework. **Stacks on #1384** (the sync-job plumbing consolidation) — the diff includes its commit until it merges; review only the last commit here.

- **The engagement refresh** becomes a per-org job chunked over the time-filter × segment × metric combinations, with a cursor that also records the combination count so a deploy that reshapes the metric list mid-run restarts the pass instead of silently skipping a shifted tail. The average response rate publishes once at completion (and never from an aborted partial pass).
- **Old contact-activity pruning** becomes a per-org job of bounded delete batches that is its own resume position — replay after any interruption converges with no cursor at all.
- **The activity-counts rebuild** becomes a per-org staged job whose whole-org recalculation runs under a lock that comfortably outlives both the job lease and the broker redelivery window — without it, a redelivered message claiming after lease expiry while the original still ran permanently doubled the org's counters (reproduced in review; the counter table has no unique constraint and the periodic squash merges duplicates into plausible-looking data).
- **Dispatch** replaces the two per-org fan-out beat entries with one dispatcher on overnight slots (off-peak anchor plus same-night retry slots), gated per job type with failure backoff anchored on the daily cadence. Queued-but-unclaimed and just-nudged jobs are recognized so slow-queue backlogs can't accumulate duplicate runs.
- The per-org disable switch is honored at every chunk, not just at enqueue, and legacy task names remain as enqueue-only shims with their registered names pinned by tests.

As rebased onto #1384, the branch adopts the consolidated framework: the shared dispatch logic (its PENDING-with-outstanding-message detection is now the framework's `include_pending` mode, modeled on this branch's fix), the shared lock context manager, `job.abort()`/`back_off()`, and checkpoint's task-declared lease default. **One deliberate behavior change stated in the commit:** dispatch cadence now anchors on when the last run started (the framework's standardized anchor) rather than when it ended, so a long pass no longer pushes the next one out by its own duration; the failure-backoff ladder is verified rung-for-rung identical. A small just-nudged guard for completed/failed jobs remains local, since the shared logic cannot cover that case. Its tests use the shared sync-job test helpers with production-shaped fixtures.

35 stats tests (108 green across stats + syncjobs), covering lock backoff, duplicate-dispatch suppression, combo-list reshaping, mid-run disables, aborted-run publishing, cadence-anchor and backoff-ladder pins, and shim/beat name pins.