### PR TITLE
Consolidate sync job dispatch, locking and test plumbing

### DIFF
--- a/ureport/contacts/sync.py
+++ b/ureport/contacts/sync.py
@@ -2,10 +2,6 @@
 
 import json
 import logging
-from datetime import timedelta
-
-from django_valkey import get_valkey_connection
-from valkey.exceptions import LockError
 
 from django.core.cache import cache
 from django.utils import timezone
@@ -14,6 +10,8 @@ from dash.orgs.models import Org, TaskState
 from ureport.backend import BaseBackend
 from ureport.celery import app
 from ureport.contacts.models import Contact
+from ureport.syncjobs.dispatch import enqueue, in_flight
+from ureport.syncjobs.locks import chunk_lock
 from ureport.syncjobs.models import LeaseLost, SyncJob
 from ureport.syncjobs.tasks import chunked_task
 from ureport.utils import datetime_to_json_date, update_cache_org_contact_counts
@@ -35,12 +33,9 @@ RATE_LIMIT_BACKOFF = 60
 LOCK_BACKOFF = 300
 
 # must comfortably exceed the slowest single chunk - the fields and boundaries stages are
-# each one unbounded pull, and a lease that expires mid chunk loses that chunk's work
+# each one unbounded pull, and a lease that expires mid chunk loses that chunk's work. It is
+# also what tells beat a running job has stopped moving, see syncjobs.dispatch.in_flight
 LEASE_SECONDS = 60 * 30
-
-# a running job is driven by its own continuations, so beat only nudges one again if it has
-# gone this long without checkpointing - i.e. its continuation was lost, not just slow
-STALE_RUN_AFTER = timedelta(seconds=LEASE_SECONDS * 2)
 
 
 def _last_fetched_key(org, backend_slug):
@@ -78,11 +73,6 @@ def finalize_contacts_sync(job):
     """
     org = job.org
     if not org:
-        return
-
-    # an aborted run stopped without covering its window, so none of the below is true of it
-    if job.progress.get("aborted"):
-        logger.info("Job #%d (%s:%s) aborted, skipping finalization", job.id, JOB_TYPE, job.scope)
         return
 
     update_cache_org_contact_counts(org)
@@ -127,30 +117,28 @@ def sync_contacts(job):
         logger.info("Contact pull disabled for org #%d, stopping", org.pk)
         return _abort_run(job, cursor)
 
-    # the ad-hoc contact tasks still coordinate through this lock: two of them rebuild
-    # counters and need exclusive access, and the mismatch check reads it to tell a sync in
-    # progress from real drift
-    r = get_valkey_connection()
-    lock = r.lock(TaskState.get_lock_key(org, JOB_TYPE), timeout=LEASE_SECONDS)
-    if not lock.acquire(blocking=False):
-        logger.info("Contact pull lock held for org #%d, backing off", org.pk)
-        return LOCK_BACKOFF
+    with _contact_pull_lock(org) as acquired:
+        if not acquired:
+            logger.info("Contact pull lock held for org #%d, backing off", org.pk)
+            return job.back_off(LOCK_BACKOFF)
 
-    try:
-        return _run_chunk(job, org, backend_obj, cursor)
-    except LeaseLost:
-        # not our run to report on anymore - the worker that took it over owns its outcome
-        raise
-    except Exception:
-        _mark_state_failing(org)
-        raise
-    finally:
         try:
-            lock.release()
-        except LockError:
-            # the chunk outlived the lock's timeout - don't let that fail an otherwise
-            # successful chunk or mask an in-flight exception
-            logger.warning("Unable to release contact pull lock for org #%d as it is no longer owned", org.pk)
+            return _run_chunk(job, org, backend_obj, cursor)
+        except LeaseLost:
+            # not our run to report on anymore - the worker that took it over owns its outcome
+            raise
+        except Exception:
+            _mark_state_failing(org)
+            raise
+
+
+def _contact_pull_lock(org):
+    """
+    The lock the ad-hoc contact tasks still coordinate through: two of them rebuild counters
+    and need exclusive access, and the mismatch check reads it to tell a sync in progress
+    from real drift.
+    """
+    return chunk_lock(TaskState.get_lock_key(org, JOB_TYPE), LEASE_SECONDS)
 
 
 def _run_chunk(job, org, backend_obj, cursor):
@@ -170,13 +158,13 @@ def _run_chunk(job, org, backend_obj, cursor):
     if stage == STAGE_FIELDS:
         counts = BaseBackend._outcome_counts_dict(backend.pull_fields(org))
         cursor["stage"] = STAGE_BOUNDARIES
-        _checkpoint(job, cursor, job.add_progress(chunks=1, **_counts("fields", counts)))
+        job.checkpoint(cursor=cursor, progress=job.add_progress(chunks=1, **_counts("fields", counts)))
         return False
 
     if stage == STAGE_BOUNDARIES:
         counts = BaseBackend._outcome_counts_dict(backend.pull_boundaries(org))
         cursor["stage"] = STAGE_CONTACTS
-        _checkpoint(job, cursor, job.add_progress(chunks=1, **_counts("boundaries", counts)))
+        job.checkpoint(cursor=cursor, progress=job.add_progress(chunks=1, **_counts("boundaries", counts)))
         return False
 
     result = backend.pull_contacts_chunk(org, cursor.get("since"), cursor.get("until"), cursor.get("resume") or {})
@@ -184,11 +172,11 @@ def _run_chunk(job, org, backend_obj, cursor):
 
     if result.done:
         # window end becomes the next run's start, and what finalization dual-writes
-        _checkpoint(job, {"last_until": cursor.get("until")}, progress)
+        job.checkpoint(cursor={"last_until": cursor.get("until")}, progress=progress)
         return True
 
     cursor["resume"] = result.cursor
-    _checkpoint(job, cursor, progress)
+    job.checkpoint(cursor=cursor, progress=progress)
 
     return RATE_LIMIT_BACKOFF if result.rate_limited else False
 
@@ -205,12 +193,7 @@ def _abort_run(job, cursor):
         since = cursor.get("since")
         cursor = {"last_until": since} if since else {}
 
-    _checkpoint(job, cursor, job.add_progress(aborted=1))
-    return True
-
-
-def _checkpoint(job, cursor, progress):
-    job.checkpoint(cursor=cursor, progress=progress, lease_seconds=LEASE_SECONDS)
+    return job.abort(cursor=cursor)
 
 
 def enqueue_org_syncs(org):
@@ -225,27 +208,15 @@ def enqueue_org_syncs(org):
     for backend_obj in org.backends.filter(is_active=True):
         job = SyncJob.get_or_create_job(org, JOB_TYPE, scope=backend_obj.slug)
 
-        if job.status == SyncJob.STATUS_PAUSED or _is_in_flight(job, now):
+        if job.status == SyncJob.STATUS_PAUSED or in_flight(job, now):
             logger.info("Job #%d (%s:%s) not nudged, %s", job.id, JOB_TYPE, job.scope, job.get_status_display())
             skipped[backend_obj.slug] = job.id
             continue
 
         enqueued[backend_obj.slug] = job.id
-        sync_contacts.apply_async((job.id,), queue=QUEUE)
+        enqueue(job)
 
     return {"enqueued": enqueued, "skipped": skipped}
-
-
-def _is_in_flight(job, now):
-    """
-    Whether a run is already being driven, so that nudging it would only start a duplicate
-    chain of chunks. The lease is released between chunks, so a running job counts as in
-    flight until its continuation stops arriving - after which beat is what recovers it.
-    """
-    if job.lease_expires_on and job.lease_expires_on > now:
-        return True
-
-    return job.status == SyncJob.STATUS_RUNNING and job.modified_on > now - STALE_RUN_AFTER
 
 
 @app.task(name="contacts.sync_contacts_dispatch")

--- a/ureport/contacts/test_sync.py
+++ b/ureport/contacts/test_sync.py
@@ -15,15 +15,16 @@ from ureport.backend import ChunkResult
 from ureport.contacts.models import Contact
 from ureport.contacts.sync import (
     JOB_TYPE,
+    LEASE_SECONDS,
     LOCK_BACKOFF,
     RATE_LIMIT_BACKOFF,
-    STALE_RUN_AFTER,
     enqueue_org_syncs,
     finalize_contacts_sync,
     sync_contacts,
     sync_contacts_dispatch,
 )
-from ureport.syncjobs.models import SyncJob
+from ureport.syncjobs.models import ABORTED, SyncJob
+from ureport.syncjobs.testing import SyncJobTestMixin, drop_lease, held_lock, make_stale, run_task
 from ureport.tests import UreportTest
 
 RAPIDPRO_BACKEND = "ureport.backend.rapidpro.RapidProBackend"
@@ -42,23 +43,7 @@ def chunk_counts(created=0, updated=0, deleted=0, ignored=0):
     return {"created": created, "updated": updated, "deleted": deleted, "ignored": ignored}
 
 
-def mock_pulls(test):
-    """
-    Patches everything a chunk reaches out of the process for, passed to the test in the
-    order patched: fields, boundaries, contacts, then the org counts refresh finalization
-    does.
-    """
-    for patcher in (
-        patch(f"{RAPIDPRO_BACKEND}.pull_fields"),
-        patch(f"{RAPIDPRO_BACKEND}.pull_boundaries"),
-        patch(f"{RAPIDPRO_BACKEND}.pull_contacts_chunk"),
-        patch("ureport.contacts.sync.update_cache_org_contact_counts"),
-    ):
-        test = patcher(test)
-    return test
-
-
-class SyncContactsTest(UreportTest):
+class SyncContactsTest(SyncJobTestMixin, UreportTest):
     def setUp(self):
         super().setUp()
 
@@ -67,25 +52,23 @@ class SyncContactsTest(UreportTest):
         self.last_fetched_key = Contact.CONTACT_LAST_FETCHED_CACHE_KEY % (self.nigeria.pk, "rapidpro")
         cache.delete(self.last_fetched_key)
 
+        # everything a chunk reaches out of the process for, and the org counts refresh
+        # finalization does
+        self.mock_pull_fields = self.start_patch(patch(f"{RAPIDPRO_BACKEND}.pull_fields"))
+        self.mock_pull_boundaries = self.start_patch(patch(f"{RAPIDPRO_BACKEND}.pull_boundaries"))
+        self.mock_pull_contacts_chunk = self.start_patch(patch(f"{RAPIDPRO_BACKEND}.pull_contacts_chunk"))
+        self.mock_update_counts = self.start_patch(patch("ureport.contacts.sync.update_cache_org_contact_counts"))
+
     def _run(self, times=1):
-        """
-        Runs the task the given number of times, as a worker would with each continuation.
-        """
-        with patch.object(sync_contacts, "apply_async") as mock_continue:
-            for _ in range(times):
-                sync_contacts(self.job.id)
-        return mock_continue
+        return run_task(sync_contacts, self.job.id, times=times)
 
     def _task_state(self):
         return TaskState.objects.filter(org=self.nigeria, task_key=JOB_TYPE).first()
 
-    @mock_pulls
-    def test_stages_run_in_order_across_chunks(
-        self, mock_pull_fields, mock_pull_boundaries, mock_pull_contacts_chunk, mock_update_counts
-    ):
-        mock_pull_fields.return_value = outcome_counts(created=1, updated=2, deleted=3, ignored=4)
-        mock_pull_boundaries.return_value = outcome_counts(created=5, updated=6, deleted=7, ignored=8)
-        mock_pull_contacts_chunk.side_effect = [
+    def test_stages_run_in_order_across_chunks(self):
+        self.mock_pull_fields.return_value = outcome_counts(created=1, updated=2, deleted=3, ignored=4)
+        self.mock_pull_boundaries.return_value = outcome_counts(created=5, updated=6, deleted=7, ignored=8)
+        self.mock_pull_contacts_chunk.side_effect = [
             ChunkResult(counts=chunk_counts(created=9, updated=10), cursor={"stage": "active", "resume": "c1"}),
             ChunkResult(counts=chunk_counts(deleted=11, ignored=12), cursor={}, done=True),
         ]
@@ -97,14 +80,14 @@ class SyncContactsTest(UreportTest):
         self.assertIsNone(job.cursor["since"])
         until = job.cursor["until"]
         mock_continue.assert_called_once_with((self.job.id,), queue="celery", countdown=None)
-        mock_pull_boundaries.assert_not_called()
+        self.mock_pull_boundaries.assert_not_called()
 
         # boundaries
         self._run()
         job = SyncJob.objects.get(id=self.job.id)
         self.assertEqual(job.cursor["stage"], "contacts")
         self.assertEqual(job.cursor["until"], until)
-        mock_pull_contacts_chunk.assert_not_called()
+        self.mock_pull_contacts_chunk.assert_not_called()
 
         # first chunk of contacts, resuming from the backend's own sub-cursor on the next
         self._run()
@@ -137,9 +120,9 @@ class SyncContactsTest(UreportTest):
             },
         )
 
-        self.assertEqual(mock_pull_contacts_chunk.call_args_list[0][0], (self.nigeria, None, until, {}))
+        self.assertEqual(self.mock_pull_contacts_chunk.call_args_list[0][0], (self.nigeria, None, until, {}))
         self.assertEqual(
-            mock_pull_contacts_chunk.call_args_list[1][0],
+            self.mock_pull_contacts_chunk.call_args_list[1][0],
             (self.nigeria, None, until, {"stage": "active", "resume": "c1"}),
         )
 
@@ -147,13 +130,10 @@ class SyncContactsTest(UreportTest):
         # it released
         self.assertIsNone(get_valkey_connection().get(TaskState.get_lock_key(self.nigeria, JOB_TYPE)))
 
-    @mock_pulls
-    def test_window_frozen_until_run_completes(
-        self, mock_pull_fields, mock_pull_boundaries, mock_pull_contacts_chunk, mock_update_counts
-    ):
-        mock_pull_fields.return_value = outcome_counts()
-        mock_pull_boundaries.return_value = outcome_counts()
-        mock_pull_contacts_chunk.side_effect = [
+    def test_window_frozen_until_run_completes(self):
+        self.mock_pull_fields.return_value = outcome_counts()
+        self.mock_pull_boundaries.return_value = outcome_counts()
+        self.mock_pull_contacts_chunk.side_effect = [
             ChunkResult(counts=chunk_counts(), cursor={"stage": "deleted"}),
             ChunkResult(counts=chunk_counts(), cursor={}, done=True),
             ChunkResult(counts=chunk_counts(), cursor={}, done=True),
@@ -168,7 +148,7 @@ class SyncContactsTest(UreportTest):
             self._run(times=2)
 
         first_until = SyncJob.objects.get(id=self.job.id).cursor["last_until"]
-        windows = [call[0][1:3] for call in mock_pull_contacts_chunk.call_args_list]
+        windows = [call[0][1:3] for call in self.mock_pull_contacts_chunk.call_args_list]
         self.assertEqual(windows, [(None, first_until), (None, first_until)])
 
         # the next run picks up where this one ended and freezes a new window
@@ -178,15 +158,14 @@ class SyncContactsTest(UreportTest):
 
         job = SyncJob.objects.get(id=self.job.id)
         self.assertNotEqual(job.cursor["last_until"], first_until)
-        self.assertEqual(mock_pull_contacts_chunk.call_args_list[-1][0][1:3], (first_until, job.cursor["last_until"]))
+        self.assertEqual(
+            self.mock_pull_contacts_chunk.call_args_list[-1][0][1:3], (first_until, job.cursor["last_until"])
+        )
 
-    @mock_pulls
-    def test_failed_run_resumes_with_the_same_window(
-        self, mock_pull_fields, mock_pull_boundaries, mock_pull_contacts_chunk, mock_update_counts
-    ):
-        mock_pull_fields.return_value = outcome_counts()
-        mock_pull_boundaries.return_value = outcome_counts()
-        mock_pull_contacts_chunk.side_effect = ValueError("boom")
+    def test_failed_run_resumes_with_the_same_window(self):
+        self.mock_pull_fields.return_value = outcome_counts()
+        self.mock_pull_boundaries.return_value = outcome_counts()
+        self.mock_pull_contacts_chunk.side_effect = ValueError("boom")
 
         self._run(times=2)  # fields, boundaries
         until = SyncJob.objects.get(id=self.job.id).cursor["until"]
@@ -202,69 +181,56 @@ class SyncContactsTest(UreportTest):
         self.assertTrue(self._task_state().is_failing)
 
         # the retry resumes the interrupted run against its frozen window
-        mock_pull_contacts_chunk.side_effect = None
-        mock_pull_contacts_chunk.return_value = ChunkResult(counts=chunk_counts(), cursor={}, done=True)
+        self.mock_pull_contacts_chunk.side_effect = None
+        self.mock_pull_contacts_chunk.return_value = ChunkResult(counts=chunk_counts(), cursor={}, done=True)
         self._run()
 
-        job = SyncJob.objects.get(id=self.job.id)
-        self.assertEqual(mock_pull_contacts_chunk.call_args[0][1:3], (None, until))
-        self.assertEqual(job.status, SyncJob.STATUS_COMPLETE)
-        self.assertEqual(job.cursor, {"last_until": until})
+        self.assertEqual(self.mock_pull_contacts_chunk.call_args[0][1:3], (None, until))
+        self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE, cursor={"last_until": until})
         self.assertFalse(self._task_state().is_failing)
 
         # the fields and boundaries stages aren't redone by the retry
-        self.assertEqual(mock_pull_fields.call_count, 1)
-        self.assertEqual(mock_pull_boundaries.call_count, 1)
+        self.assertEqual(self.mock_pull_fields.call_count, 1)
+        self.assertEqual(self.mock_pull_boundaries.call_count, 1)
 
-    @mock_pulls
-    def test_lost_lease_discards_the_chunk(
-        self, mock_pull_fields, mock_pull_boundaries, mock_pull_contacts_chunk, mock_update_counts
-    ):
+    def test_lost_lease_discards_the_chunk(self):
         def steal_lease(org):
             SyncJob.objects.filter(id=self.job.id).update(lease_owner="thief")
             return outcome_counts()
 
-        mock_pull_fields.side_effect = steal_lease
-        mock_pull_boundaries.return_value = outcome_counts()
+        self.mock_pull_fields.side_effect = steal_lease
+        self.mock_pull_boundaries.return_value = outcome_counts()
 
         self._run()
 
         # the stage advance went down with the chunk - nothing was written
-        job = SyncJob.objects.get(id=self.job.id)
-        self.assertEqual(job.cursor, {})
-        self.assertEqual(job.status, SyncJob.STATUS_RUNNING)
+        self.assertJobState(self.job, cursor={}, status=SyncJob.STATUS_RUNNING)
         self.assertIsNone(self._task_state())  # a lost lease isn't this worker's failure
 
         # so the run that takes over pulls the fields stage again
-        mock_pull_fields.side_effect = None
-        mock_pull_fields.return_value = outcome_counts()
-        SyncJob.objects.filter(id=self.job.id).update(lease_owner=None, lease_expires_on=None)
+        self.mock_pull_fields.side_effect = None
+        self.mock_pull_fields.return_value = outcome_counts()
+        drop_lease(self.job)
 
         self._run()
 
-        self.assertEqual(mock_pull_fields.call_count, 2)
+        self.assertEqual(self.mock_pull_fields.call_count, 2)
         self.assertEqual(SyncJob.objects.get(id=self.job.id).cursor["stage"], "boundaries")
 
-    @mock_pulls
-    def test_first_run_seeds_since_from_legacy_cache_key(
-        self, mock_pull_fields, mock_pull_boundaries, mock_pull_contacts_chunk, mock_update_counts
-    ):
+    def test_first_run_seeds_since_from_legacy_cache_key(self):
         cache.set(self.last_fetched_key, "2026-08-10T10:00:00.000Z", None)
-        mock_pull_fields.return_value = outcome_counts()
-        mock_pull_boundaries.return_value = outcome_counts()
-        mock_pull_contacts_chunk.return_value = ChunkResult(counts=chunk_counts(), cursor={}, done=True)
+        self.mock_pull_fields.return_value = outcome_counts()
+        self.mock_pull_boundaries.return_value = outcome_counts()
+        self.mock_pull_contacts_chunk.return_value = ChunkResult(counts=chunk_counts(), cursor={}, done=True)
 
         self._run(times=3)
 
-        self.assertEqual(mock_pull_contacts_chunk.call_args[0][1], "2026-08-10T10:00:00.000Z")
+        self.assertEqual(self.mock_pull_contacts_chunk.call_args[0][1], "2026-08-10T10:00:00.000Z")
 
-    @mock_pulls
-    def test_rate_limited_chunk_delays_continuation(
-        self, mock_pull_fields, mock_pull_boundaries, mock_pull_contacts_chunk, mock_update_counts
-    ):
-        mock_pull_fields.return_value = outcome_counts()
-        mock_pull_boundaries.return_value = outcome_counts()
-        mock_pull_contacts_chunk.return_value = ChunkResult(
+    def test_rate_limited_chunk_delays_continuation(self):
+        self.mock_pull_fields.return_value = outcome_counts()
+        self.mock_pull_boundaries.return_value = outcome_counts()
+        self.mock_pull_contacts_chunk.return_value = ChunkResult(
             counts=chunk_counts(created=3), cursor={"stage": "active", "resume": "c1"}, rate_limited=True
         )
 
@@ -278,34 +244,23 @@ class SyncContactsTest(UreportTest):
         self.assertEqual(job.progress["contacts_created"], 3)
         self.assertEqual(job.cursor["resume"], {"stage": "active", "resume": "c1"})
 
-    @mock_pulls
-    def test_backs_off_while_another_contact_task_holds_the_lock(
-        self, mock_pull_fields, mock_pull_boundaries, mock_pull_contacts_chunk, mock_update_counts
-    ):
-        lock = get_valkey_connection().lock(TaskState.get_lock_key(self.nigeria, JOB_TYPE), timeout=60)
-        self.assertTrue(lock.acquire(blocking=False))
-
-        try:
+    def test_backs_off_while_another_contact_task_holds_the_lock(self):
+        with held_lock(TaskState.get_lock_key(self.nigeria, JOB_TYPE)):
             mock_continue = self._run()
-        finally:
-            lock.release()
 
         mock_continue.assert_called_once_with((self.job.id,), queue="celery", countdown=LOCK_BACKOFF)
-        mock_pull_fields.assert_not_called()
-        self.assertEqual(SyncJob.objects.get(id=self.job.id).cursor, {})
+        self.mock_pull_fields.assert_not_called()
+        self.assertJobState(self.job, cursor={})
 
-    @mock_pulls
-    def test_completion_finalizes(
-        self, mock_pull_fields, mock_pull_boundaries, mock_pull_contacts_chunk, mock_update_counts
-    ):
-        mock_pull_fields.return_value = outcome_counts()
-        mock_pull_boundaries.return_value = outcome_counts()
-        mock_pull_contacts_chunk.return_value = ChunkResult(counts=chunk_counts(), cursor={}, done=True)
+    def test_completion_finalizes(self):
+        self.mock_pull_fields.return_value = outcome_counts()
+        self.mock_pull_boundaries.return_value = outcome_counts()
+        self.mock_pull_contacts_chunk.return_value = ChunkResult(counts=chunk_counts(), cursor={}, done=True)
 
         self._run(times=3)
 
         job = SyncJob.objects.get(id=self.job.id)
-        mock_update_counts.assert_called_once_with(self.nigeria)
+        self.mock_update_counts.assert_called_once_with(self.nigeria)
         self.assertFalse(job.needs_finalize)
 
         # the pre-chunking task's resume point is kept up to date so a rollback resumes here
@@ -324,10 +279,7 @@ class SyncContactsTest(UreportTest):
         self.assertEqual(cache.get(self.last_fetched_key), job.cursor["last_until"])
         self.assertEqual(json.loads(self._task_state().last_results), {"rapidpro": job.progress})
 
-    @mock_pulls
-    def test_finalize_keeps_the_other_backends_results(
-        self, mock_pull_fields, mock_pull_boundaries, mock_pull_contacts_chunk, mock_update_counts
-    ):
+    def test_finalize_keeps_the_other_backends_results(self):
         self.nigeria.backends.create(
             slug="floip",
             backend_type=RAPIDPRO_BACKEND,
@@ -336,9 +288,9 @@ class SyncContactsTest(UreportTest):
             created_by=self.admin,
             modified_by=self.admin,
         )
-        mock_pull_fields.return_value = outcome_counts()
-        mock_pull_boundaries.return_value = outcome_counts()
-        mock_pull_contacts_chunk.return_value = ChunkResult(counts=chunk_counts(created=1), cursor={}, done=True)
+        self.mock_pull_fields.return_value = outcome_counts()
+        self.mock_pull_boundaries.return_value = outcome_counts()
+        self.mock_pull_contacts_chunk.return_value = ChunkResult(counts=chunk_counts(created=1), cursor={}, done=True)
 
         self._run(times=3)
         rapidpro_progress = SyncJob.objects.get(id=self.job.id).progress
@@ -352,68 +304,54 @@ class SyncContactsTest(UreportTest):
             {"rapidpro": rapidpro_progress, "floip": floip_progress},
         )
 
-    @mock_pulls
-    def test_deactivated_backend_aborts_the_run(
-        self, mock_pull_fields, mock_pull_boundaries, mock_pull_contacts_chunk, mock_update_counts
-    ):
+    def test_deactivated_backend_aborts_the_run(self):
         cache.set(self.last_fetched_key, "2026-08-10T10:00:00.000Z", None)
-        mock_pull_fields.return_value = outcome_counts()
-        mock_pull_boundaries.return_value = outcome_counts()
+        self.mock_pull_fields.return_value = outcome_counts()
+        self.mock_pull_boundaries.return_value = outcome_counts()
 
         self._run(times=2)  # fields, boundaries - a run with a window in flight
         self.nigeria.backends.filter(slug="rapidpro").update(is_active=False)
 
         self._run()
 
-        job = SyncJob.objects.get(id=self.job.id)
-        self.assertEqual(job.status, SyncJob.STATUS_COMPLETE)
-        mock_pull_contacts_chunk.assert_not_called()
+        self.mock_pull_contacts_chunk.assert_not_called()
 
         # the window this run never covered is left for the next one to pull again, and the
         # page cursor it was resuming from is dropped with it
-        self.assertEqual(job.cursor, {"last_until": "2026-08-10T10:00:00.000Z"})
+        self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE, cursor={"last_until": "2026-08-10T10:00:00.000Z"})
 
         # a run that didn't sync anything isn't reported as one that did
         self.assertEqual(cache.get(self.last_fetched_key), "2026-08-10T10:00:00.000Z")
         self.assertIsNone(self._task_state())
-        mock_update_counts.assert_not_called()
+        self.mock_update_counts.assert_not_called()
 
-    @mock_pulls
-    def test_deactivated_backend_leaves_an_idle_job_alone(
-        self, mock_pull_fields, mock_pull_boundaries, mock_pull_contacts_chunk, mock_update_counts
-    ):
+    def test_deactivated_backend_leaves_an_idle_job_alone(self):
         SyncJob.objects.filter(id=self.job.id).update(cursor={"last_until": "2026-08-10T10:00:00.000Z"})
         self.nigeria.backends.filter(slug="rapidpro").update(is_active=False)
 
         self._run()
 
-        job = SyncJob.objects.get(id=self.job.id)
-        self.assertEqual(job.status, SyncJob.STATUS_COMPLETE)
-        self.assertEqual(job.cursor, {"last_until": "2026-08-10T10:00:00.000Z"})
-        mock_pull_fields.assert_not_called()
+        self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE, cursor={"last_until": "2026-08-10T10:00:00.000Z"})
+        self.mock_pull_fields.assert_not_called()
 
-    @mock_pulls
-    def test_disabling_the_pull_aborts_the_run(
-        self, mock_pull_fields, mock_pull_boundaries, mock_pull_contacts_chunk, mock_update_counts
-    ):
-        mock_pull_fields.return_value = outcome_counts()
-        mock_pull_boundaries.return_value = outcome_counts()
+    def test_disabling_the_pull_aborts_the_run(self):
+        self.mock_pull_fields.return_value = outcome_counts()
+        self.mock_pull_boundaries.return_value = outcome_counts()
 
         self._run(times=2)  # fields, boundaries
         TaskState.objects.update_or_create(org=self.nigeria, task_key=JOB_TYPE, defaults={"is_disabled": True})
 
         self._run()
 
-        job = SyncJob.objects.get(id=self.job.id)
-        self.assertEqual(job.status, SyncJob.STATUS_COMPLETE)
-        self.assertEqual(job.cursor, {})  # nothing to resume from, and no window claimed
-        self.assertEqual(job.progress["aborted"], 1)
-        mock_pull_contacts_chunk.assert_not_called()
+        # nothing to resume from, and no window claimed
+        job = self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE, cursor={})
+        self.assertEqual(job.progress[ABORTED], 1)
+        self.mock_pull_contacts_chunk.assert_not_called()
 
         state = self._task_state()
         self.assertIsNone(state.last_successfully_started_on)
         self.assertIsNone(cache.get(self.last_fetched_key))
-        mock_update_counts.assert_not_called()
+        self.mock_update_counts.assert_not_called()
 
 
 class DispatchTest(UreportTest):
@@ -473,7 +411,7 @@ class DispatchTest(UreportTest):
         mock_enqueue.assert_not_called()
 
         # a run that stopped checkpointing entirely lost its continuation, so nudge it
-        SyncJob.objects.filter(id=job.id).update(modified_on=timezone.now() - STALE_RUN_AFTER - timedelta(minutes=1))
+        make_stale(job, seconds_ago=2 * LEASE_SECONDS + 60)
 
         with patch.object(sync_contacts, "apply_async") as mock_enqueue:
             sync_contacts_dispatch()

--- a/ureport/polls/sync.py
+++ b/ureport/polls/sync.py
@@ -4,11 +4,11 @@ import logging
 from datetime import timedelta
 
 from django.core.cache import cache
-from django.db.models import Q
 from django.utils import timezone
 
 from dash.orgs.models import Org
 from ureport.celery import app
+from ureport.syncjobs.dispatch import Backoff, enqueue, is_due
 from ureport.syncjobs.models import SyncJob
 from ureport.syncjobs.tasks import chunked_task
 
@@ -40,11 +40,9 @@ MAIN_POLL_INTERVAL = timedelta(minutes=20)
 RECENT_POLLS_INTERVAL = timedelta(hours=1)
 OTHER_POLLS_INTERVAL = timedelta(hours=24)
 
-# a failing job backs off exponentially from this, so a deterministically broken sync isn't
-# retried at the dispatcher's full rate
-FAILURE_BACKOFF = timedelta(minutes=20)
-MAX_FAILURE_BACKOFF = timedelta(hours=24)
-MAX_BACKOFF_DOUBLINGS = 10
+# a failing job backs off exponentially, so a deterministically broken sync isn't retried at
+# the dispatcher's full rate
+FAILURE_BACKOFF = Backoff(base=timedelta(minutes=20), cap=timedelta(hours=24), max_doublings=10)
 
 # other polls created this recently are covered by the recent polls cadence
 OTHER_POLLS_NEW_WINDOW = timedelta(days=7)
@@ -69,14 +67,14 @@ def queue_results_sync(org, flow_uuid, reset_cursor=False):
     """
     Ensures the results job for this flow exists and asks for a chunk of it to run.
     """
-    return _queue(sync_poll_results, SyncJob.get_or_create_job(org, RESULTS_JOB_TYPE, flow_uuid), reset_cursor)
+    return _queue(SyncJob.get_or_create_job(org, RESULTS_JOB_TYPE, flow_uuid), reset_cursor)
 
 
 def queue_archives_sync(org, flow_uuid, reset_cursor=False):
     """
     Ensures the archives job for this flow exists and asks for a chunk of it to run.
     """
-    return _queue(sync_poll_archives, SyncJob.get_or_create_job(org, ARCHIVES_JOB_TYPE, flow_uuid), reset_cursor)
+    return _queue(SyncJob.get_or_create_job(org, ARCHIVES_JOB_TYPE, flow_uuid), reset_cursor)
 
 
 def is_flow_syncing(org_id, flow_uuid):
@@ -93,34 +91,12 @@ def is_flow_syncing(org_id, flow_uuid):
     ).exists()
 
 
-def _queue(task, job, reset_cursor=False):
+def _queue(job, reset_cursor=False):
     if reset_cursor:
-        _reset_cursor(job)
+        job.reset_cursor()
 
-    _enqueue(task, job)
+    enqueue(job)
     return job
-
-
-def _enqueue(task, job):
-    task.apply_async((job.id,), queue=SYNC_QUEUE)
-
-
-def _reset_cursor(job):
-    """
-    Sends a job back to the start of its traversal, e.g. when the results it synced have
-    been deleted. A job under a live lease is left alone - its worker owns the cursor -
-    so callers must retry a refused reset rather than assume it landed.
-    """
-    now = timezone.now()
-    updated = (
-        SyncJob.objects.filter(id=job.id)
-        .filter(Q(lease_expires_on__isnull=True) | Q(lease_expires_on__lt=now))
-        .update(cursor={}, modified_on=now)
-    )
-    if updated:
-        job.refresh_from_db()
-
-    return bool(updated)
 
 
 def _get_backend(poll):
@@ -170,11 +146,11 @@ def _queue_archives_rewalk(poll):
     """
     job = SyncJob.get_or_create_job(poll.org, ARCHIVES_JOB_TYPE, poll.flow_uuid)
 
-    reset = _reset_cursor(job)
+    reset = job.reset_cursor()
     if not reset:
         logger.warning("Archives job #%d is still running, deferring its cursor reset" % job.id)
 
-    _enqueue(sync_poll_archives, job)
+    enqueue(job)
     return reset
 
 
@@ -254,14 +230,14 @@ def sync_poll_results(job):
         # flag and the legacy position key, so a crash in between would leave the old
         # cursor resuming an incremental pull over results that are gone. Crashing after
         # this checkpoint instead just deletes and re-pulls again, which is harmless.
-        job.checkpoint(cursor={}, lease_seconds=RESULTS_LEASE_SECONDS)
+        job.checkpoint(cursor={})
         cursor = {}
 
         _delete_flow_results(job, poll)
 
         # everything synced so far is discarded, so the archives have to be walked again too
         reset_pending = not _queue_archives_rewalk(poll)
-        job.checkpoint(progress=_set_reset_pending(job.progress, reset_pending), lease_seconds=RESULTS_LEASE_SECONDS)
+        job.checkpoint(progress=_set_reset_pending(job.progress, reset_pending))
     else:
         if reset_pending:
             reset_pending = not _queue_archives_rewalk(poll)
@@ -285,7 +261,7 @@ def sync_poll_results(job):
     result = _get_backend(poll).pull_results_chunk(poll, cursor)
 
     progress = _set_reset_pending(job.add_progress(chunks=1, **result.counts), reset_pending)
-    job.checkpoint(cursor=result.cursor, progress=progress, lease_seconds=RESULTS_LEASE_SECONDS)
+    job.checkpoint(cursor=result.cursor, progress=progress)
 
     if result.done:
         return True
@@ -295,7 +271,7 @@ def sync_poll_results(job):
 
         # a rebuild of a big flow can outlast the lease, so renew before the next chunk -
         # if it's gone this raises and the chunk is dropped rather than writing on
-        job.checkpoint(lease_seconds=RESULTS_LEASE_SECONDS)
+        job.checkpoint()
 
     return RATE_LIMITED_BACKOFF if result.rate_limited else False
 
@@ -314,11 +290,7 @@ def sync_poll_archives(job):
 
     result = _get_backend(poll).pull_results_from_archives_chunk(poll, dict(job.cursor or {}))
 
-    job.checkpoint(
-        cursor=result.cursor,
-        progress=job.add_progress(chunks=1, **result.counts),
-        lease_seconds=ARCHIVES_LEASE_SECONDS,
-    )
+    job.checkpoint(cursor=result.cursor, progress=job.add_progress(chunks=1, **result.counts))
 
     if result.done:
         return True
@@ -380,8 +352,8 @@ def dispatch_archives(org):
 
     jobs = SyncJob.objects.filter(org=org, job_type=ARCHIVES_JOB_TYPE).exclude(status=SyncJob.STATUS_COMPLETE)
     for job in jobs:
-        if _is_due(job, None, now):
-            _enqueue(sync_poll_archives, job)
+        if is_due(job, now, backoff=FAILURE_BACKOFF):
+            enqueue(job)
             queued.append(job.scope)
 
     return queued
@@ -405,47 +377,8 @@ def dispatch_flows(org, flow_uuids, interval=None, handled=None):
         handled.add(flow_uuid)
 
         job = SyncJob.get_or_create_job(org, RESULTS_JOB_TYPE, flow_uuid)
-        if _is_due(job, interval, now):
-            _queue(sync_poll_results, job)
+        if is_due(job, now, interval=interval, backoff=FAILURE_BACKOFF):
+            _queue(job)
             queued.append(flow_uuid)
 
     return queued
-
-
-def _is_due(job, interval, now):
-    """
-    A job is due unless it is paused, a run is still moving, or its last run ended recently
-    enough - for the cadence asked for, an interval of None meaning any finished run is
-    stale, or for the backoff its failure streak has earned. The failure backoff matters
-    because a job that fails deterministically would otherwise be retried on every pass.
-    """
-    if job.status == SyncJob.STATUS_PAUSED or _in_flight(job, now):
-        return False
-
-    wait = interval
-    if job.consecutive_failures:
-        doublings = min(job.consecutive_failures - 1, MAX_BACKOFF_DOUBLINGS)
-        backoff = min(FAILURE_BACKOFF * 2**doublings, MAX_FAILURE_BACKOFF)
-        wait = max(wait, backoff) if wait else backoff
-
-    if not wait:
-        return True
-
-    return not (job.ended_on and job.ended_on > now - wait)
-
-
-def _in_flight(job, now):
-    """
-    Whether a run is still moving: a live lease, or a running job that checkpointed
-    recently - chunks release the lease between continuations, so a healthy run looks idle
-    from here while its next message waits in the queue. A running job that stopped
-    checkpointing is deliberately not in flight: nudging it is how a chain that died
-    without recording a failure gets picked back up.
-    """
-    if job.lease_expires_on and job.lease_expires_on > now:
-        return True
-
-    lease_seconds = ARCHIVES_LEASE_SECONDS if job.job_type == ARCHIVES_JOB_TYPE else RESULTS_LEASE_SECONDS
-    stale_after = now - timedelta(seconds=2 * lease_seconds)
-
-    return job.status == SyncJob.STATUS_RUNNING and bool(job.modified_on) and job.modified_on > stale_after

--- a/ureport/polls/test_sync.py
+++ b/ureport/polls/test_sync.py
@@ -32,6 +32,7 @@ from ureport.polls.tasks import (
 )
 from ureport.polls.views import PollCRUDL
 from ureport.syncjobs.models import SyncJob
+from ureport.syncjobs.testing import SyncJobTestMixin, drop_lease, end_run, hold_lease, make_stale, run_task
 from ureport.tests import UreportTest
 from ureport.utils import datetime_to_json_date
 
@@ -50,7 +51,7 @@ def results_counts(**overrides):
     return counts
 
 
-class PollSyncTestBase(UreportTest):
+class PollSyncTestBase(SyncJobTestMixin, UreportTest):
     def setUp(self):
         super(PollSyncTestBase, self).setUp()
 
@@ -86,11 +87,6 @@ class SyncPollResultsTest(PollSyncTestBase):
         self.mock_queue_archives = self.start_patch(patch.object(sync_poll_archives, "apply_async"))
         self.mock_rebuild = self.start_patch(patch.object(Poll, "rebuild_poll_results_counts"))
 
-    def start_patch(self, patcher):
-        mock = patcher.start()
-        self.addCleanup(patcher.stop)
-        return mock
-
     def test_seeds_cursor_from_legacy_cache_key(self):
         cache.set(Poll.POLL_RESULTS_LAST_PULL_CACHE_KEY % (self.nigeria.pk, "uuid-1"), "2026-08-01T10:00:00.000Z", None)
 
@@ -98,16 +94,14 @@ class SyncPollResultsTest(PollSyncTestBase):
             mock_chunk.return_value = ChunkResult(
                 counts=results_counts(num_val_created=3), cursor={"after": "2026-08-02T10:00:00.000Z"}, done=True
             )
-            with patch.object(sync_poll_results, "apply_async"):
-                sync_poll_results(self.job.id)
+            run_task(sync_poll_results, self.job.id)
 
         self.assertEqual(mock_chunk.call_args[0][1], {"after": "2026-08-01T10:00:00.000Z"})
 
     def test_starts_from_scratch_without_legacy_position(self):
         with patch.object(RapidProBackend, "pull_results_chunk") as mock_chunk:
             mock_chunk.return_value = ChunkResult(counts=results_counts(), cursor={"after": None}, done=True)
-            with patch.object(sync_poll_results, "apply_async"):
-                sync_poll_results(self.job.id)
+            run_task(sync_poll_results, self.job.id)
 
         self.assertEqual(mock_chunk.call_args[0][1], {})
 
@@ -122,23 +116,17 @@ class SyncPollResultsTest(PollSyncTestBase):
         with patch.object(RapidProBackend, "pull_results_chunk") as mock_chunk:
             mock_chunk.side_effect = chunks
 
-            with patch.object(sync_poll_results, "apply_async") as mock_continue:
-                sync_poll_results(self.job.id)
+            mock_continue = run_task(sync_poll_results, self.job.id)
+            mock_continue.assert_called_once_with((self.job.id,), queue="sync", countdown=None)
 
-                mock_continue.assert_called_once_with((self.job.id,), queue="sync", countdown=None)
+            self.assertJobState(self.job, status=SyncJob.STATUS_RUNNING, cursor={"after": "t1", "resume": "c1"})
 
-                job = self.get_job()
-                self.assertEqual(job.status, SyncJob.STATUS_RUNNING)
-                self.assertEqual(job.cursor, {"after": "t1", "resume": "c1"})
-
-                # the continuation picks up from the checkpointed position
-                sync_poll_results(self.job.id)
+            # the continuation picks up from the checkpointed position
+            run_task(sync_poll_results, self.job.id)
 
         self.assertEqual(mock_chunk.call_args_list[1][0][1], {"after": "t1", "resume": "c1"})
 
-        job = self.get_job()
-        self.assertEqual(job.status, SyncJob.STATUS_COMPLETE)
-        self.assertEqual(job.cursor, {"after": "t2"})
+        job = self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE, cursor={"after": "t2"})
         self.assertEqual(job.progress["chunks"], 2)
         self.assertEqual(job.progress["num_val_created"], 3)
         self.assertEqual(job.progress["num_synced"], 15)
@@ -148,11 +136,10 @@ class SyncPollResultsTest(PollSyncTestBase):
             mock_chunk.return_value = ChunkResult(
                 counts=results_counts(), cursor={"after": "t1", "resume": "c1"}, rate_limited=True
             )
-            with patch.object(sync_poll_results, "apply_async") as mock_continue:
-                sync_poll_results(self.job.id)
+            mock_continue = run_task(sync_poll_results, self.job.id)
 
         mock_continue.assert_called_once_with((self.job.id,), queue="sync", countdown=RATE_LIMITED_BACKOFF)
-        self.assertEqual(self.get_job().cursor, {"after": "t1", "resume": "c1"})
+        self.assertJobState(self.job, cursor={"after": "t1", "resume": "c1"})
 
     def test_rebuilds_counts_periodically(self):
         # a run four chunks in, i.e. between chunks of an interrupted traversal
@@ -161,14 +148,13 @@ class SyncPollResultsTest(PollSyncTestBase):
         with patch.object(RapidProBackend, "pull_results_chunk") as mock_chunk:
             mock_chunk.return_value = ChunkResult(counts=results_counts(num_val_created=1), cursor={"after": "t5"})
 
-            with patch.object(sync_poll_results, "apply_async"):
-                # the fifth chunk rebuilds so partial results reach the public site
-                sync_poll_results(self.job.id)
-                self.mock_rebuild.assert_called_once()
+            # the fifth chunk rebuilds so partial results reach the public site
+            run_task(sync_poll_results, self.job.id)
+            self.mock_rebuild.assert_called_once()
 
-                self.mock_rebuild.reset_mock()
-                sync_poll_results(self.job.id)
-                self.mock_rebuild.assert_not_called()
+            self.mock_rebuild.reset_mock()
+            run_task(sync_poll_results, self.job.id)
+            self.mock_rebuild.assert_not_called()
 
     def test_queues_archives_on_first_sync(self):
         self.mock_flow_date.return_value = None
@@ -176,8 +162,7 @@ class SyncPollResultsTest(PollSyncTestBase):
         with patch.object(RapidProBackend, "pull_results_chunk") as mock_chunk:
             mock_chunk.return_value = ChunkResult(counts=results_counts(), cursor={"after": "t1"}, done=True)
 
-            with patch.object(sync_poll_results, "apply_async"):
-                sync_poll_results(self.job.id)
+            run_task(sync_poll_results, self.job.id)
 
         archives_job = self.get_job(ARCHIVES_JOB_TYPE)
         self.mock_queue_archives.assert_called_once_with((archives_job.id,), queue="sync")
@@ -186,14 +171,13 @@ class SyncPollResultsTest(PollSyncTestBase):
         with patch.object(RapidProBackend, "pull_results_chunk") as mock_chunk:
             mock_chunk.return_value = ChunkResult(counts=results_counts(), cursor={"after": "t1"}, done=True)
 
-            with patch.object(sync_poll_results, "apply_async"):
-                sync_poll_results(self.job.id)
-                self.mock_queue_archives.assert_not_called()
+            run_task(sync_poll_results, self.job.id)
+            self.mock_queue_archives.assert_not_called()
 
-                # nor once the polls on the flow have completed their first sync
-                self.mock_flow_date.return_value = None
-                sync_poll_results(self.job.id)
-                self.mock_queue_archives.assert_not_called()
+            # nor once the polls on the flow have completed their first sync
+            self.mock_flow_date.return_value = None
+            run_task(sync_poll_results, self.job.id)
+            self.mock_queue_archives.assert_not_called()
 
         self.assertTrue(Poll.objects.get(id=self.poll.id).has_synced)
         self.assertFalse(SyncJob.objects.filter(job_type=ARCHIVES_JOB_TYPE).exists())
@@ -216,8 +200,7 @@ class SyncPollResultsTest(PollSyncTestBase):
         with patch.object(RapidProBackend, "pull_results_chunk") as mock_chunk:
             mock_chunk.return_value = ChunkResult(counts=results_counts(), cursor={"after": "t2"}, done=True)
 
-            with patch.object(sync_poll_results, "apply_async"):
-                sync_poll_results(self.job.id)
+            run_task(sync_poll_results, self.job.id)
 
         # the traversal starts over, the deleted results are gone and the archives are walked again
         self.assertEqual(mock_chunk.call_args[0][1], {})
@@ -243,12 +226,10 @@ class SyncPollResultsTest(PollSyncTestBase):
                 with self.assertRaises(ValueError):
                     sync_poll_results(self.job.id)
 
-                job = self.get_job()
-                self.assertEqual(job.status, SyncJob.STATUS_FAILED)
-                self.assertEqual(job.cursor, {})
+            self.assertJobState(self.job, status=SyncJob.STATUS_FAILED, cursor={})
 
-                # the retry pulls from scratch rather than resuming past the deleted results
-                sync_poll_results(self.job.id)
+            # the retry pulls from scratch rather than resuming past the deleted results
+            run_task(sync_poll_results, self.job.id)
 
         self.assertEqual(mock_chunk.call_args[0][1], {})
 
@@ -263,8 +244,7 @@ class SyncPollResultsTest(PollSyncTestBase):
         with patch.object(RapidProBackend, "pull_results_chunk") as mock_chunk:
             mock_chunk.return_value = ChunkResult(counts=results_counts(), cursor={"after": "t2"}, done=True)
 
-            with patch.object(sync_poll_results, "apply_async"):
-                sync_poll_results(self.job.id)
+            run_task(sync_poll_results, self.job.id)
 
         self.assertEqual(mock_chunk.call_args[0][1], {})
         self.assertEqual(mock_chunk.call_args[0][0].pk, newest.pk)
@@ -288,15 +268,14 @@ class SyncPollResultsTest(PollSyncTestBase):
         with patch.object(RapidProBackend, "pull_results_chunk") as mock_chunk:
             mock_chunk.return_value = ChunkResult(counts=results_counts(), cursor={"after": "t2"})
 
-            with patch.object(sync_poll_results, "apply_async"):
-                sync_poll_results(self.job.id)
+            run_task(sync_poll_results, self.job.id)
 
-                # its worker still owns the cursor, so the reset is deferred, not dropped
-                self.assertEqual(self.get_job(ARCHIVES_JOB_TYPE).cursor, {"before": "2026-01-01"})
-                self.assertEqual(self.get_job().progress["archives_reset_pending"], 1)
+            # its worker still owns the cursor, so the reset is deferred, not dropped
+            self.assertEqual(self.get_job(ARCHIVES_JOB_TYPE).cursor, {"before": "2026-01-01"})
+            self.assertEqual(self.get_job().progress["archives_reset_pending"], 1)
 
-                SyncJob.objects.filter(id=archives_job.id).update(lease_owner=None, lease_expires_on=None)
-                sync_poll_results(self.job.id)
+            drop_lease(archives_job)
+            run_task(sync_poll_results, self.job.id)
 
         self.assertEqual(self.get_job(ARCHIVES_JOB_TYPE).cursor, {})
         self.assertNotIn("archives_reset_pending", self.get_job().progress)
@@ -314,7 +293,7 @@ class SyncPollResultsTest(PollSyncTestBase):
                 with self.assertRaises(ValueError):
                     sync_poll_results(self.job.id)
 
-                sync_poll_results(self.job.id)
+            run_task(sync_poll_results, self.job.id)
 
         # one job, nudged by both attempts - the failed one never got to run the archives
         self.assertEqual(SyncJob.objects.filter(job_type=ARCHIVES_JOB_TYPE, scope="uuid-1").count(), 1)
@@ -324,8 +303,7 @@ class SyncPollResultsTest(PollSyncTestBase):
         with patch.object(RapidProBackend, "pull_results_chunk") as mock_chunk:
             mock_chunk.return_value = ChunkResult(counts=results_counts(num_val_ignored=7), cursor={}, done=True)
 
-            with patch.object(sync_poll_results, "apply_async"):
-                sync_poll_results(self.job.id)
+            run_task(sync_poll_results, self.job.id)
 
         self.mock_rebuild.assert_not_called()
         self.assertTrue(Poll.objects.get(id=self.poll.id).has_synced)
@@ -342,13 +320,12 @@ class SyncPollResultsTest(PollSyncTestBase):
         with patch.object(RapidProBackend, "pull_results_chunk") as mock_chunk:
             mock_chunk.return_value = ChunkResult(counts=results_counts(), cursor={"after": "t2"}, done=True)
 
-            with patch.object(sync_poll_results, "apply_async"):
-                sync_poll_results(self.job.id)
+            run_task(sync_poll_results, self.job.id)
 
         # the leftover finalize saw the completed run's counters, this run's changed nothing
         self.mock_rebuild.assert_called_once()
         self.assertTrue(Poll.objects.get(id=self.poll.id).has_synced)
-        self.assertFalse(self.get_job().needs_finalize)
+        self.assertJobState(self.job, needs_finalize=False)
         self.assertEqual(cache.get(Poll.POLL_RESULTS_LAST_PULL_CACHE_KEY % (self.nigeria.pk, "uuid-1")), "t2")
 
     def test_completed_cursor_is_not_reseeded_from_the_legacy_key(self):
@@ -359,8 +336,7 @@ class SyncPollResultsTest(PollSyncTestBase):
         with patch.object(RapidProBackend, "pull_results_chunk") as mock_chunk:
             mock_chunk.return_value = ChunkResult(counts=results_counts(), cursor={"after": "t3"}, done=True)
 
-            with patch.object(sync_poll_results, "apply_async"):
-                sync_poll_results(self.job.id)
+            run_task(sync_poll_results, self.job.id)
 
         self.assertEqual(mock_chunk.call_args[0][1], {"after": "t2"})
 
@@ -371,8 +347,7 @@ class SyncPollResultsTest(PollSyncTestBase):
             mock_chunk.return_value = ChunkResult(
                 counts=results_counts(num_val_created=1), cursor={"after": "2026-08-11T09:00:00.000Z"}, done=True
             )
-            with patch.object(sync_poll_results, "apply_async"):
-                sync_poll_results(self.job.id)
+            run_task(sync_poll_results, self.job.id)
 
         self.mock_rebuild.assert_called_once()
 
@@ -391,13 +366,12 @@ class SyncPollResultsTest(PollSyncTestBase):
         Poll.objects.filter(id=self.poll.id).update(stopped_syncing=True)
 
         with patch.object(RapidProBackend, "pull_results_chunk") as mock_chunk:
-            with patch.object(sync_poll_results, "apply_async") as mock_continue:
-                sync_poll_results(self.job.id)
+            mock_continue = run_task(sync_poll_results, self.job.id)
 
         mock_chunk.assert_not_called()
         mock_continue.assert_not_called()
         self.mock_rebuild.assert_not_called()
-        self.assertEqual(self.get_job().status, SyncJob.STATUS_COMPLETE)
+        self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE)
 
 
 class SyncPollArchivesTest(PollSyncTestBase):
@@ -415,20 +389,16 @@ class SyncPollArchivesTest(PollSyncTestBase):
         with patch.object(RapidProBackend, "pull_results_from_archives_chunk") as mock_chunk:
             mock_chunk.side_effect = chunks
 
-            with (
-                patch.object(sync_poll_archives, "apply_async") as mock_continue,
-                patch.object(Poll, "rebuild_poll_results_counts") as mock_rebuild,
-            ):
-                sync_poll_archives(self.job.id)
+            with patch.object(Poll, "rebuild_poll_results_counts") as mock_rebuild:
+                mock_continue = run_task(sync_poll_archives, self.job.id)
                 mock_continue.assert_called_once_with((self.job.id,), queue="sync", countdown=None)
 
-                sync_poll_archives(self.job.id)
+                run_task(sync_poll_archives, self.job.id)
 
         self.assertEqual(mock_chunk.call_args_list[1][0][1], {"before": "2026-07-01", "seen": ["a"]})
         mock_rebuild.assert_called_once()
 
-        job = self.get_job(ARCHIVES_JOB_TYPE)
-        self.assertEqual(job.status, SyncJob.STATUS_COMPLETE)
+        job = self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE)
         self.assertEqual(job.progress["chunks"], 2)
 
         self.poll.refresh_from_db()
@@ -438,11 +408,8 @@ class SyncPollArchivesTest(PollSyncTestBase):
         with patch.object(RapidProBackend, "pull_results_from_archives_chunk") as mock_chunk:
             mock_chunk.return_value = ChunkResult(counts=results_counts(), cursor={"before": "2026-06-01"}, done=True)
 
-            with (
-                patch.object(sync_poll_archives, "apply_async"),
-                patch.object(Poll, "rebuild_poll_results_counts") as mock_rebuild,
-            ):
-                sync_poll_archives(self.job.id)
+            with patch.object(Poll, "rebuild_poll_results_counts") as mock_rebuild:
+                run_task(sync_poll_archives, self.job.id)
 
         mock_rebuild.assert_not_called()
         self.poll.refresh_from_db()
@@ -453,8 +420,7 @@ class SyncPollArchivesTest(PollSyncTestBase):
             mock_chunk.return_value = ChunkResult(
                 counts=results_counts(), cursor={"before": "2026-07-01"}, rate_limited=True
             )
-            with patch.object(sync_poll_archives, "apply_async") as mock_continue:
-                sync_poll_archives(self.job.id)
+            mock_continue = run_task(sync_poll_archives, self.job.id)
 
         mock_continue.assert_called_once_with((self.job.id,), queue="sync", countdown=RATE_LIMITED_BACKOFF)
 
@@ -492,35 +458,86 @@ class DispatchTest(PollSyncTestBase):
 
     def test_queues_unsynced_polls_every_pass(self):
         # the unsynced poll is queued even though its job just completed
-        job = SyncJob.get_or_create_job(self.nigeria, RESULTS_JOB_TYPE, "uuid-1")
-        SyncJob.objects.filter(id=job.id).update(status=SyncJob.STATUS_COMPLETE, ended_on=timezone.now())
+        end_run(SyncJob.get_or_create_job(self.nigeria, RESULTS_JOB_TYPE, "uuid-1"))
 
         self.assertIn("uuid-1", self.dispatch())
+
+    def complete_runs(self, started_on, ended_on):
+        """
+        Leaves every results job of the org as a run that started and ended when given.
+        """
+        SyncJob.objects.filter(org=self.nigeria, job_type=RESULTS_JOB_TYPE).update(
+            status=SyncJob.STATUS_COMPLETE, started_on=started_on, ended_on=ended_on
+        )
 
     def test_respects_cadence_of_completed_jobs(self):
         now = timezone.now()
         self.assertEqual(self.dispatch(), {"uuid-1", "uuid-main", "uuid-other"})
 
-        SyncJob.objects.filter(org=self.nigeria, job_type=RESULTS_JOB_TYPE).update(
-            status=SyncJob.STATUS_COMPLETE, ended_on=now - timedelta(minutes=10)
-        )
+        self.complete_runs(now - timedelta(minutes=11), now - timedelta(minutes=10))
         self.assertEqual(self.dispatch(), {"uuid-1"})
 
         # the main poll is due again after twenty minutes, the other poll only after a day
-        SyncJob.objects.filter(org=self.nigeria, job_type=RESULTS_JOB_TYPE).update(
-            status=SyncJob.STATUS_COMPLETE, ended_on=now - timedelta(minutes=30)
-        )
+        self.complete_runs(now - timedelta(minutes=31), now - timedelta(minutes=30))
         self.assertEqual(self.dispatch(), {"uuid-1", "uuid-main"})
 
-        SyncJob.objects.filter(org=self.nigeria, job_type=RESULTS_JOB_TYPE).update(
-            status=SyncJob.STATUS_COMPLETE, ended_on=now - timedelta(days=2)
-        )
+        self.complete_runs(now - timedelta(days=2), now - timedelta(days=2))
         self.assertEqual(self.dispatch(), {"uuid-1", "uuid-main", "uuid-other"})
 
-    def test_skips_jobs_under_a_live_lease(self):
-        SyncJob.objects.filter(id=SyncJob.get_or_create_job(self.nigeria, RESULTS_JOB_TYPE, "uuid-1").id).update(
-            lease_owner="worker-1", lease_expires_on=timezone.now() + timedelta(minutes=5)
+    def test_cadence_is_spent_by_a_long_run(self):
+        # the cadence is how often a run should start, so a run that takes longer than it
+        # leaves the next one due as soon as it ends rather than a whole cadence later
+        now = timezone.now()
+        self.dispatch()  # the jobs the cadence applies to exist once their flows are dispatched
+
+        self.complete_runs(now - timedelta(hours=3), now - timedelta(minutes=1))
+
+        self.assertEqual(self.dispatch(), {"uuid-1", "uuid-main"})
+
+        # the daily cadence hasn't been spent by three hours, so the other poll waits
+        self.complete_runs(now - timedelta(days=2), now - timedelta(minutes=1))
+        self.assertEqual(self.dispatch(), {"uuid-1", "uuid-main", "uuid-other"})
+
+    def test_failure_backoff_never_outpaces_the_cadence(self):
+        # a job that fails after a run long enough to spend its cadence is held back by the
+        # backoff alone, which must not retry it faster than it would run when healthy
+        now = timezone.now()
+        job = SyncJob.get_or_create_job(self.nigeria, RESULTS_JOB_TYPE, "uuid-other")
+        end_run(
+            job,
+            status=SyncJob.STATUS_FAILED,
+            started_on=now - timedelta(days=3),
+            ended_on=now - timedelta(hours=2),
+            failures=1,
         )
+
+        self.assertNotIn("uuid-other", self.dispatch())
+
+        # and once its own cadence is up, it is retried
+        end_run(
+            job,
+            status=SyncJob.STATUS_FAILED,
+            started_on=now - timedelta(days=3),
+            ended_on=now - timedelta(days=2),
+            failures=1,
+        )
+
+        self.assertIn("uuid-other", self.dispatch())
+
+    def test_nudges_a_run_that_never_ended(self):
+        # a chain that died without recording a failure left no end to schedule the next run
+        # from, so it is nudged as soon as it stops checkpointing, whatever its cadence
+        now = timezone.now()
+        job = SyncJob.get_or_create_job(self.nigeria, RESULTS_JOB_TYPE, "uuid-other")
+        SyncJob.objects.filter(id=job.id).update(
+            status=SyncJob.STATUS_RUNNING, started_on=now - timedelta(minutes=5), ended_on=None
+        )
+        make_stale(job, seconds_ago=3 * 60 * 60)
+
+        self.assertIn("uuid-other", self.dispatch())
+
+    def test_skips_jobs_under_a_live_lease(self):
+        hold_lease(SyncJob.get_or_create_job(self.nigeria, RESULTS_JOB_TYPE, "uuid-1"))
 
         self.assertNotIn("uuid-1", self.dispatch())
 
@@ -533,7 +550,7 @@ class DispatchTest(PollSyncTestBase):
 
         # but a run that stopped checkpointing is picked back up - the recovery nudge for a
         # chain that died without recording a failure
-        SyncJob.objects.filter(id=job.id).update(modified_on=timezone.now() - timedelta(hours=3))
+        make_stale(job, seconds_ago=3 * 60 * 60)
 
         self.assertIn("uuid-1", self.dispatch())
 
@@ -542,19 +559,17 @@ class DispatchTest(PollSyncTestBase):
         job = SyncJob.get_or_create_job(self.nigeria, RESULTS_JOB_TYPE, "uuid-1")
 
         # a failed job is not retried at the dispatcher's rate, even at the always-due cadence
-        SyncJob.objects.filter(id=job.id).update(
-            status=SyncJob.STATUS_FAILED, ended_on=now - timedelta(minutes=5), consecutive_failures=1
-        )
+        end_run(job, status=SyncJob.STATUS_FAILED, ended_on=now - timedelta(minutes=5), failures=1)
         self.assertNotIn("uuid-1", self.dispatch())
 
-        SyncJob.objects.filter(id=job.id).update(ended_on=now - timedelta(minutes=25))
+        end_run(job, status=SyncJob.STATUS_FAILED, ended_on=now - timedelta(minutes=25), failures=1)
         self.assertIn("uuid-1", self.dispatch())
 
         # and the streak stretches the wait
-        SyncJob.objects.filter(id=job.id).update(consecutive_failures=3)
+        end_run(job, status=SyncJob.STATUS_FAILED, ended_on=now - timedelta(minutes=25), failures=3)
         self.assertNotIn("uuid-1", self.dispatch())
 
-        SyncJob.objects.filter(id=job.id).update(ended_on=now - timedelta(hours=3))
+        end_run(job, status=SyncJob.STATUS_FAILED, ended_on=now - timedelta(hours=3), failures=3)
         self.assertIn("uuid-1", self.dispatch())
 
     def test_never_queues_paused_jobs(self):
@@ -566,11 +581,9 @@ class DispatchTest(PollSyncTestBase):
     def test_nudges_unfinished_archive_traversals(self):
         now = timezone.now()
         failed = SyncJob.get_or_create_job(self.nigeria, ARCHIVES_JOB_TYPE, "uuid-1")
-        SyncJob.objects.filter(id=failed.id).update(
-            status=SyncJob.STATUS_FAILED, ended_on=now - timedelta(hours=2), consecutive_failures=1
-        )
+        end_run(failed, status=SyncJob.STATUS_FAILED, ended_on=now - timedelta(hours=2), failures=1)
         done = SyncJob.get_or_create_job(self.nigeria, ARCHIVES_JOB_TYPE, "uuid-main")
-        SyncJob.objects.filter(id=done.id).update(status=SyncJob.STATUS_COMPLETE, ended_on=now)
+        end_run(done, ended_on=now)
         paused = SyncJob.get_or_create_job(self.nigeria, ARCHIVES_JOB_TYPE, "uuid-other")
         SyncJob.objects.filter(id=paused.id).update(status=SyncJob.STATUS_PAUSED)
 
@@ -628,7 +641,7 @@ class TaskShimTest(PollSyncTestBase):
 
     def test_pull_refresh_from_archives_restarts_the_traversal(self):
         job = SyncJob.get_or_create_job(self.nigeria, ARCHIVES_JOB_TYPE, "uuid-1")
-        SyncJob.objects.filter(id=job.id).update(status=SyncJob.STATUS_COMPLETE, cursor={"before": "2026-01-01"})
+        end_run(job, cursor={"before": "2026-01-01"})
 
         with patch.object(sync_poll_archives, "apply_async") as mock_queue:
             pull_refresh_from_archives(self.poll.pk)
@@ -694,17 +707,14 @@ class ClearOldResultsTest(PollSyncTestBase):
 
     def test_leaves_a_flow_alone_while_its_sync_holds_the_lease(self):
         job = SyncJob.get_or_create_job(self.nigeria, RESULTS_JOB_TYPE, "uuid-1")
-        SyncJob.objects.filter(id=job.id).update(
-            status=SyncJob.STATUS_RUNNING,
-            lease_owner="worker-1",
-            lease_expires_on=timezone.now() + timedelta(minutes=5),
-        )
+        SyncJob.objects.filter(id=job.id).update(status=SyncJob.STATUS_RUNNING)
+        hold_lease(job)
 
         self.clear().assert_not_called()
         self.assertFalse(Poll.objects.get(id=self.poll.id).stopped_syncing)
 
         # once the lease is gone the results can be cleared
-        SyncJob.objects.filter(id=job.id).update(lease_owner=None, lease_expires_on=None)
+        drop_lease(job)
 
         self.clear().assert_called_once()
         self.assertTrue(Poll.objects.get(id=self.poll.id).stopped_syncing)
@@ -725,14 +735,11 @@ class SyncStatusTest(PollSyncTestBase):
         job = SyncJob.get_or_create_job(self.nigeria, RESULTS_JOB_TYPE, "uuid-1")
         self.assertEqual(self.view.get_sync_status(self.poll), "Synced")
 
-        SyncJob.objects.filter(id=job.id).update(
-            status=SyncJob.STATUS_COMPLETE, ended_on=timezone.now() - timedelta(hours=8)
-        )
+        end_run(job, ended_on=timezone.now() - timedelta(hours=8))
         self.assertIn("8", self.view.get_sync_status(self.poll))
 
-        SyncJob.objects.filter(id=job.id).update(
-            status=SyncJob.STATUS_RUNNING, lease_expires_on=timezone.now() + timedelta(minutes=5)
-        )
+        SyncJob.objects.filter(id=job.id).update(status=SyncJob.STATUS_RUNNING)
+        hold_lease(job)
         self.assertIn("in progress", self.view.get_sync_status(self.poll))
 
     def test_reports_progress_for_an_unsynced_poll(self):

--- a/ureport/syncjobs/dispatch.py
+++ b/ureport/syncjobs/dispatch.py
@@ -1,0 +1,98 @@
+from collections import namedtuple
+from datetime import timedelta
+
+from .models import DEFAULT_LEASE_SECONDS, SyncJob
+from .tasks import JOB_TASKS
+
+# an exponential wait after a failure: the first one waits base, each further one doubles it
+# up to max_doublings times, and none of them waits longer than cap
+Backoff = namedtuple("Backoff", ("base", "cap", "max_doublings"))
+
+
+def enqueue(job, countdown=None):
+    """
+    Asks for a chunk of this job to run, on the queue its task is declared with. Enqueueing
+    is all a trigger does - the task itself decides whether the job is claimable.
+    """
+    task = JOB_TASKS.get(job.job_type)
+    if task is None:
+        raise KeyError(f"no task registered for job type '{job.job_type}' - is the module declaring it imported?")
+
+    options = dict(queue=task.queue)
+    if countdown is not None:
+        options["countdown"] = countdown
+
+    task.apply_async((job.id,), **options)
+
+
+def is_due(job, now, *, interval=None, backoff=None):
+    """
+    Whether a dispatcher should nudge this job: it isn't paused, no run is already moving,
+    and enough time has passed since its last run - the cadence asked for, an interval of
+    None meaning any run that isn't moving is due, or the wait its failure streak has
+    earned. The failure backoff matters because a job that fails deterministically would
+    otherwise be retried on every pass.
+    """
+    if job.status == SyncJob.STATUS_PAUSED or in_flight(job, now):
+        return False
+
+    if backoff and job.consecutive_failures:
+        # a wait after the failure rather than a cadence, so it is measured from the end of
+        # the run that failed - and never lets a job be retried faster than its own cadence,
+        # which a run long enough to outlast that cadence would otherwise do
+        doublings = min(job.consecutive_failures - 1, backoff.max_doublings)
+        wait = min(backoff.base * 2**doublings, backoff.cap)
+        if interval:
+            wait = max(wait, interval)
+
+        return not (job.ended_on and job.ended_on > now - wait)
+
+    # the cadence is how often a run should start, so it is measured from the last start. A
+    # run that never ended isn't waited out at all: there is nothing to schedule the next one
+    # from, and nudging is how a chain that died without recording a failure is picked up
+    if interval and job.ended_on:
+        # a job that ended without ever starting only comes out of a fixture, but the fall
+        # back keeps one from being read as never having run at all
+        anchor = job.started_on or job.ended_on
+        if anchor > now - interval:
+            return False
+
+    return True
+
+
+def in_flight(job, now, *, include_pending=False):
+    """
+    Whether a run is already being driven, so that nudging it would only start a duplicate
+    chain of chunks: a live lease, or a running job that checkpointed recently - chunks
+    release the lease between continuations, so a healthy run looks idle from here while its
+    next message waits in the queue.
+
+    A running job that stopped checkpointing is deliberately not in flight: nudging it is how
+    a chain that died without recording a failure gets picked back up.
+
+    With include_pending, a job that hasn't run yet but was touched recently counts too -
+    for callers whose enqueue records the nudge, where a fresh modified_on means a message
+    is already on the queue. A job whose row was only just created has never been nudged
+    though, and its caller has to tell those two apart itself - get_or_create's created flag
+    is what does it.
+    """
+    if job.lease_expires_on and job.lease_expires_on > now:
+        return True
+
+    if not _recently_touched(job, now):
+        return False
+
+    statuses = (SyncJob.STATUS_RUNNING, SyncJob.STATUS_PENDING) if include_pending else (SyncJob.STATUS_RUNNING,)
+
+    return job.status in statuses
+
+
+def _recently_touched(job, now):
+    """
+    Whether anything has happened to this job lately - a claim, a checkpoint, or a nudge -
+    measured generously enough that a chunk taking its whole lease still counts.
+    """
+    task = JOB_TASKS.get(job.job_type)
+    lease_seconds = getattr(task, "lease_seconds", DEFAULT_LEASE_SECONDS)
+
+    return bool(job.modified_on) and job.modified_on > now - timedelta(seconds=2 * lease_seconds)

--- a/ureport/syncjobs/locks.py
+++ b/ureport/syncjobs/locks.py
@@ -1,0 +1,30 @@
+import logging
+from contextlib import contextmanager
+
+from django_valkey import get_valkey_connection
+from valkey.exceptions import LockError
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def chunk_lock(key, timeout):
+    """
+    Takes a lock for the duration of one chunk, yielding whether it was taken. Never blocks -
+    a chunk that can't have the lock backs off and comes back rather than tying up a worker
+    waiting - and the timeout must comfortably outlive the chunk, as the work it guards
+    carries on regardless once it lapses.
+    """
+    lock = get_valkey_connection().lock(key, timeout=timeout)
+    acquired = lock.acquire(blocking=False)
+
+    try:
+        yield acquired
+    finally:
+        if acquired:
+            try:
+                lock.release()
+            except LockError:
+                # the chunk outlived the lock's timeout - don't let that fail an otherwise
+                # successful chunk or mask an in-flight exception
+                logger.warning("Unable to release lock %s as it is no longer owned", key)

--- a/ureport/syncjobs/models.py
+++ b/ureport/syncjobs/models.py
@@ -26,6 +26,10 @@ DEFAULT_FAILING_THRESHOLD = 3
 # where the monitor task leaves its findings for the status page
 STATUS_CACHE_KEY = "syncjobs_status"
 
+# progress key marking a run that ended without covering its work - see SyncJob.abort. Named
+# so that it can't collide with a counter an app keeps, whatever it calls it
+ABORTED = "__aborted"
+
 
 class LeaseLost(Exception):
     """
@@ -113,6 +117,15 @@ class SyncJob(models.Model):
 
     objects = SyncJobQuerySet.as_manager()
 
+    # how long the lease a chunk renews at each checkpoint lasts. Stamped by chunked_task on
+    # the job it hands its chunk, from what the task declared - a job fetched anywhere else,
+    # including one a chunk re-fetches for itself, checkpoints for the default instead
+    lease_seconds = DEFAULT_LEASE_SECONDS
+
+    # whether the claim this job is held under started a run rather than resuming one, set
+    # by claim(). Unclaimed jobs aren't running anything, so nothing is fresh about them
+    new_run = False
+
     class Meta:
         constraints = [
             models.UniqueConstraint(
@@ -134,7 +147,8 @@ class SyncJob(models.Model):
         live lease is not - including the lease deliberately held through finalization.
         Claiming a job whose previous run finished (or never started) begins a new run;
         claiming a running or failed job resumes the interrupted run. Returns the refreshed
-        job if the claim succeeded, None otherwise.
+        job - with new_run saying which of those it did - if the claim succeeded, None
+        otherwise.
         """
         now = timezone.now()
         resuming = Q(status__in=(self.STATUS_RUNNING, self.STATUS_FAILED))
@@ -160,18 +174,30 @@ class SyncJob(models.Model):
             return None
 
         self.refresh_from_db()
+
+        # only a claim that started a run stamped this now onto started_on, so it is what
+        # says which of the two this claim was - the state the job was in beforehand can't,
+        # a run may have ended between reading it and claiming
+        self.new_run = self.started_on == now
+
         return self
 
-    def checkpoint(self, cursor=None, progress=None, lease_seconds=DEFAULT_LEASE_SECONDS):
+    def checkpoint(self, cursor=None, progress=None, lease_seconds=None):
         """
         Persists the job's resume position and renews its lease. When the chunk's data
         writes are transactional, call this inside the same transaction so the cursor can
         never run ahead of or behind the data; chunks whose writes autocommit must instead
         make them idempotent under replay from the previous cursor. Raises LeaseLost if
         this worker no longer owns the job.
+
+        The lease is renewed for as long as the task declared when it claimed the job,
+        unless a chunk asks for something different.
         """
         if not self.lease_owner:
             raise LeaseLost(f"no lease held on job #{self.id} ({self.job_type}:{self.scope})")
+
+        if lease_seconds is None:
+            lease_seconds = self.lease_seconds
 
         now = timezone.now()
         updates = dict(lease_expires_on=now + timedelta(seconds=lease_seconds), modified_on=now)
@@ -198,6 +224,28 @@ class SyncJob(models.Model):
         for key, value in counts.items():
             progress[key] = progress.get(key, 0) + value
         return progress
+
+    def abort(self, cursor=None, **counts):
+        """
+        Ends a run that can't do the work it was claimed for - the thing it syncs went away,
+        or was disabled - by checkpointing the position the next run should pick up from
+        (nothing, unless the chunk knows better) and marking the run aborted, so that
+        completion doesn't report it as a run that covered its work. Returns True, i.e. done,
+        so that a chunk can return it directly.
+        """
+        self.checkpoint(cursor={} if cursor is None else cursor, progress=self.add_progress(**counts, **{ABORTED: 1}))
+        return True
+
+    def back_off(self, seconds, **counts):
+        """
+        Records that this chunk couldn't do its work yet - typically because something it
+        needs is held elsewhere - and returns the delay to wait before the continuation, so
+        that a chunk can return it directly. Only writes if there are counters to record.
+        """
+        if counts:
+            self.checkpoint(progress=self.add_progress(**counts))
+
+        return seconds
 
     def mark_complete(self, needs_finalize=False):
         """
@@ -341,6 +389,18 @@ class SyncJob(models.Model):
         self.refresh_from_db()
         return True
 
+    def reset_cursor(self):
+        """
+        Sends a job back to the start of its traversal, e.g. when what it synced has been
+        deleted, without otherwise disturbing its run state. A job under a live lease is
+        left alone - its worker owns the cursor - so callers must retry a refused reset
+        rather than assume it landed. Returns whether it was applied.
+
+        A refusal is left for the caller to report: unlike an operator's action, it is an
+        ordinary outcome, and what it means depends on what the caller does about it.
+        """
+        return self._update_unleased(warn=False, cursor={})
+
     def force_resync(self):
         """
         Discards the job's resume position so the next run starts from scratch, e.g. after
@@ -359,10 +419,11 @@ class SyncJob(models.Model):
             lease_expires_on=None,
         )
 
-    def _update_unleased(self, **updates):
+    def _update_unleased(self, warn=True, **updates):
         """
-        Applies an operator update only while no worker holds a live lease, so manual
-        intervention can never clobber a chunk that is still running.
+        Applies an update only while no worker holds a live lease, so it can never clobber a
+        chunk that is still running. A refusal is worth reporting for an operator's action,
+        which is why it warns unless the caller says it does its own reporting.
         """
         now = timezone.now()
 
@@ -372,7 +433,8 @@ class SyncJob(models.Model):
             .update(modified_on=now, **updates)
         )
         if not updated:
-            logger.warning("Job #%d (%s:%s) is leased, update skipped", self.id, self.job_type, self.scope)
+            if warn:
+                logger.warning("Job #%d (%s:%s) is leased, update skipped", self.id, self.job_type, self.scope)
             return False
 
         self.refresh_from_db()

--- a/ureport/syncjobs/tasks.py
+++ b/ureport/syncjobs/tasks.py
@@ -5,11 +5,12 @@ import uuid
 from celery.exceptions import MaxRetriesExceededError
 
 from django.core.cache import cache
+from django.core.exceptions import ImproperlyConfigured
 from django.utils import timezone
 
 from ureport.celery import app
 
-from .models import DEFAULT_LEASE_SECONDS, STATUS_CACHE_KEY, LeaseLost, SyncJob
+from .models import ABORTED, DEFAULT_LEASE_SECONDS, STATUS_CACHE_KEY, LeaseLost, SyncJob
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +19,11 @@ LEASE_RETRY_GRACE = 5
 
 # how many problem jobs the monitor task describes in detail, counts cover the rest
 MAX_REPORTED_JOBS = 50
+
+# the task that runs each job type, by job type - filled in as the chunked tasks are
+# declared, so that anything holding a job can enqueue or size up its work without having to
+# know which module the task lives in. See ureport.syncjobs.dispatch.
+JOB_TASKS = {}
 
 
 @app.task(name="syncjobs.check_jobs")
@@ -55,7 +61,7 @@ def check_jobs():
     cache.set(STATUS_CACHE_KEY, output, None)
 
 
-def chunked_task(job_type, queue="celery", lease_seconds=DEFAULT_LEASE_SECONDS, finalize=None, name=None):
+def chunked_task(job_type, name, queue="celery", lease_seconds=DEFAULT_LEASE_SECONDS, finalize=None):
     """
     Creates a Celery task that runs a SyncJob one bounded chunk at a time. The decorated
     function performs a single chunk of work: it reads its resume position from job.cursor,
@@ -74,13 +80,13 @@ def chunked_task(job_type, queue="celery", lease_seconds=DEFAULT_LEASE_SECONDS, 
     be idempotent: it runs at least once per completed run and can run again after crashes,
     takeovers or duplicate triggers. If the worker dies between completing and finalizing,
     the job's needs_finalize flag makes the next invocation run the leftover finalization
-    first - against the completed run's state, before this invocation's run touches it.
+    first - against the completed run's state, before this invocation's run touches it. A
+    run a chunk aborted (see SyncJob.abort) is not finalized at all - there is nothing it
+    covered to report on.
     """
 
     def decorator(chunk_func):
-        task_name = name or f"syncjobs.{job_type}"
-
-        @app.task(name=task_name, bind=True, queue=queue, acks_late=True, reject_on_worker_lost=True)
+        @app.task(name=name, bind=True, queue=queue, acks_late=True, reject_on_worker_lost=True)
         def _task(self, job_id):
             job = SyncJob.objects.filter(id=job_id).first()
             if not job:
@@ -99,10 +105,14 @@ def chunked_task(job_type, queue="celery", lease_seconds=DEFAULT_LEASE_SECONDS, 
                 _retry_if_leased(self, job_id)
                 return
 
+            # the lease the chunk's checkpoints renew for - the claim already told it whether
+            # it is starting a run or resuming one
+            job.lease_seconds = lease_seconds
+
             try:
                 if snapshot.needs_finalize:
                     if finalize:
-                        finalize(snapshot)
+                        _finalize_run(snapshot)
                     job.clear_finalize()
 
                 done = chunk_func(job)
@@ -120,13 +130,16 @@ def chunked_task(job_type, queue="celery", lease_seconds=DEFAULT_LEASE_SECONDS, 
                     return  # job was taken over - the new holder owns finalization
                 if finalize:
                     try:
-                        finalize(job)
+                        _finalize_run(job)
                     except Exception:
                         # record the failure so backoff engages and release the lease so
                         # the retry needn't wait out its expiry; needs_finalize stays set
                         # so the retry runs the leftover finalization before anything else
                         job.record_failure(traceback.format_exc())
                         raise
+
+                    # the flag is cleared even for a run nothing was finalized for - there
+                    # is nothing left for the next invocation to pick up
                     job.clear_finalize()
                 job.release_lease()
             else:
@@ -138,6 +151,17 @@ def chunked_task(job_type, queue="celery", lease_seconds=DEFAULT_LEASE_SECONDS, 
                 # against our still-held lease instead of racing the release
                 _task.apply_async((job_id,), queue=queue, countdown=countdown)
                 job.release_lease()
+
+        def _finalize_run(state):
+            """
+            Runs the finalize hook against the state of the run it belongs to, unless that
+            run was aborted - it never covered the work finalization reports on.
+            """
+            if _was_aborted(state):
+                logger.info("Job #%s (%s) aborted, skipping finalization", state.id, job_type)
+                return
+
+            finalize(state)
 
         def _retry_if_leased(task_self, job_id):
             """
@@ -162,6 +186,32 @@ def chunked_task(job_type, queue="celery", lease_seconds=DEFAULT_LEASE_SECONDS, 
             else:
                 logger.info("Job #%s (%s) not claimable, skipping", job_id, job_type)
 
+        # what a job of this type is run by - the queue comes with the task itself
+        _task.lease_seconds = lease_seconds
+        _register(job_type, _task)
+
         return _task
 
     return decorator
+
+
+def _register(job_type, task):
+    """
+    Records which task runs a job type, so that a job can be enqueued and sized up from
+    anywhere. One task owns a job type: two would each drive the other's jobs from a
+    different module, on whatever queue and lease they happened to declare.
+    """
+    registered = JOB_TASKS.get(job_type)
+    if registered is not None and registered.name != task.name:
+        raise ImproperlyConfigured(
+            f"job type '{job_type}' is already run by task '{registered.name}', can't also be run by '{task.name}'"
+        )
+
+    JOB_TASKS[job_type] = task
+
+
+def _was_aborted(job):
+    """
+    Whether the run ended without covering its work - see SyncJob.abort.
+    """
+    return bool((job.progress or {}).get(ABORTED))

--- a/ureport/syncjobs/testing.py
+++ b/ureport/syncjobs/testing.py
@@ -1,0 +1,191 @@
+"""
+Plumbing for testing sync jobs: the arrange code every app that runs them needs - putting a
+job into a given state, and driving its task the way a worker would, one chunk per delivery
+with the continuation enqueue captured rather than executed.
+"""
+
+import uuid
+from contextlib import contextmanager
+from datetime import timedelta
+from unittest.mock import patch
+
+from django_valkey import get_valkey_connection
+
+from django.utils import timezone
+
+from .models import SyncJob
+from .tasks import JOB_TASKS, chunked_task
+
+DEFAULT_MAX_CHUNKS = 20
+
+# tells apart "leave this as it is" from an explicitly asked for null
+UNSET = object()
+
+
+def make_task(chunks_to_run, finalize=None, fail_on_chunk=None, job_type="test-sync", queue="testq"):
+    """
+    Builds a chunked task that pretends to have the given number of chunks of work,
+    recording each chunk it runs. Returns the task and the list it records into.
+    """
+    ran = []
+
+    # a test's task stands in for whatever else runs this job type, which the registry
+    # otherwise refuses - SyncJobTestMixin puts back what was registered before the test
+    JOB_TASKS.pop(job_type, None)
+
+    @chunked_task(job_type, queue=queue, finalize=finalize, name=f"test.sync.{uuid.uuid4().hex}")
+    def sync_test(job):
+        chunk = job.cursor.get("chunk", 0)
+        if fail_on_chunk is not None and chunk == fail_on_chunk:
+            raise ValueError(f"failing on chunk {chunk}")
+
+        ran.append(chunk)
+        job.checkpoint(cursor={"chunk": chunk + 1}, progress=job.add_progress(chunks=1))
+        return chunk + 1 >= chunks_to_run
+
+    return sync_test, ran
+
+
+def run_task(task, job_id, times=1):
+    """
+    Runs the task the given number of times, as a worker would with each delivery. Returns
+    the patched apply_async, i.e. the continuations those runs asked for.
+    """
+    with patch.object(task, "apply_async") as mock_enqueue:
+        for _ in range(times):
+            task(job_id)
+
+    return mock_enqueue
+
+
+def run_to_completion(task, job_id, max_chunks=DEFAULT_MAX_CHUNKS):
+    """
+    Drives the job until a run of it completes, returning how many chunks that took. Fails
+    rather than looping forever on a job that never finishes, and rather than passing off
+    the other ways a chunk can stop asking for a continuation - a lost lease, a pause - as
+    a completed run.
+    """
+    with patch.object(task, "apply_async") as mock_enqueue:
+        for chunks in range(1, max_chunks + 1):
+            asked_for = mock_enqueue.call_count
+            task(job_id)
+
+            if mock_enqueue.call_count == asked_for:
+                job = SyncJob.objects.get(id=job_id)
+                if job.status != SyncJob.STATUS_COMPLETE or job.needs_finalize or job.lease_owner:
+                    raise AssertionError(f"job #{job_id} stopped without completing its run: {job}")
+
+                return chunks
+
+    raise AssertionError(f"job #{job_id} still not done after {max_chunks} chunks")
+
+
+def reload(job):
+    """
+    The job as it now is in the database, leaving the caller's own copy alone.
+    """
+    return SyncJob.objects.get(id=job.id)
+
+
+def hold_lease(job, owner="worker-1", seconds=600):
+    """
+    Puts a live lease on the job without claiming it, i.e. someone else is working on it.
+    """
+    return _update(job, lease_owner=owner, lease_expires_on=timezone.now() + timedelta(seconds=seconds))
+
+
+def expire_lease(job, seconds_ago=1):
+    """
+    Expires the lease the job holds, as if its worker died mid chunk.
+    """
+    return _update(job, lease_expires_on=timezone.now() - timedelta(seconds=seconds_ago))
+
+
+def drop_lease(job):
+    """
+    Drops the job's lease without going through its holder, i.e. the between chunks state.
+    """
+    return _update(job, lease_owner=None, lease_expires_on=None)
+
+
+def make_stale(job, seconds_ago):
+    """
+    Backdates when the job was last touched, i.e. it stopped checkpointing that long ago.
+    """
+    return _update(job, modified_on=timezone.now() - timedelta(seconds=seconds_ago))
+
+
+def end_run(job, status=SyncJob.STATUS_COMPLETE, ended_on=None, started_on=UNSET, failures=None, **updates):
+    """
+    Leaves the job as a run that ended - completed by default, failed with a streak of that
+    many failures when failures is given - which is the state a dispatcher reads a cadence
+    and a backoff from. A run that ended has started, so started_on defaults to when it
+    ended: pass one to give the run a length, or None for a row nothing ever claimed.
+    """
+    ended_on = ended_on or timezone.now()
+    if failures is not None:
+        updates["consecutive_failures"] = failures
+
+    return _update(
+        job, status=status, started_on=ended_on if started_on is UNSET else started_on, ended_on=ended_on, **updates
+    )
+
+
+@contextmanager
+def held_lock(key, timeout=60):
+    """
+    Holds a lock for the duration of the block, i.e. something else has it.
+    """
+    lock = get_valkey_connection().lock(key, timeout=timeout)
+    if not lock.acquire(blocking=False):
+        raise AssertionError(f"lock {key} is already held")
+
+    try:
+        yield lock
+    finally:
+        lock.release()
+
+
+def _update(job, **updates):
+    SyncJob.objects.filter(id=job.id).update(**updates)
+    job.refresh_from_db()
+
+    return job
+
+
+class SyncJobTestMixin:
+    """
+    Assertions and patching helpers for tests that drive sync jobs.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        # the task registry is process wide, so a test declaring its own tasks would
+        # otherwise leave them running the job types of every test after it
+        registered = dict(JOB_TASKS)
+        self.addCleanup(self._restore_job_tasks, registered)
+
+    def _restore_job_tasks(self, registered):
+        JOB_TASKS.clear()
+        JOB_TASKS.update(registered)
+
+    def assertJobState(self, job, **expected):
+        """
+        Asserts the given fields of the job as it now is in the database.
+        """
+        current = reload(job)
+
+        for field, value in expected.items():
+            self.assertEqual(getattr(current, field), value, f"unexpected {field} on job #{job.id}")
+
+        return current
+
+    def start_patch(self, patcher):
+        """
+        Starts a patcher for the duration of the test, returning its mock.
+        """
+        mock = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        return mock

--- a/ureport/syncjobs/tests.py
+++ b/ureport/syncjobs/tests.py
@@ -6,19 +6,43 @@ from celery.exceptions import Retry
 
 from django.contrib.auth.models import User
 from django.core.cache import cache
+from django.core.exceptions import ImproperlyConfigured
 from django.db import IntegrityError, transaction
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 
 from dash.orgs.models import Org
-from ureport.syncjobs.models import MAX_ERROR_LENGTH, MAX_ERROR_SUMMARY_LENGTH, STATUS_CACHE_KEY, LeaseLost, SyncJob
-from ureport.syncjobs.tasks import MAX_REPORTED_JOBS, check_jobs, chunked_task
+from ureport.syncjobs.dispatch import Backoff, enqueue, in_flight, is_due
+from ureport.syncjobs.models import (
+    ABORTED,
+    DEFAULT_LEASE_SECONDS,
+    MAX_ERROR_LENGTH,
+    MAX_ERROR_SUMMARY_LENGTH,
+    STATUS_CACHE_KEY,
+    LeaseLost,
+    SyncJob,
+)
+from ureport.syncjobs.tasks import JOB_TASKS, MAX_REPORTED_JOBS, check_jobs, chunked_task
+from ureport.syncjobs.testing import (
+    SyncJobTestMixin,
+    drop_lease,
+    end_run,
+    expire_lease,
+    hold_lease,
+    make_stale,
+    make_task,
+    reload,
+    run_task,
+    run_to_completion,
+)
 from ureport.tests import UreportTest
 
 
-class SyncJobTest(TestCase):
+class SyncJobTest(SyncJobTestMixin, TestCase):
     def setUp(self):
+        super().setUp()
+
         self.job = SyncJob.get_or_create_job(None, "test-sync", "flow-1")
 
     def test_get_or_create_is_idempotent(self):
@@ -152,6 +176,86 @@ class SyncJobTest(TestCase):
         self.assertGreater(self.job.lease_expires_on, first_expiry)
         self.assertEqual(self.job.cursor, {"after": "t1"})
 
+    def test_checkpoint_renews_for_the_declared_lease(self):
+        # a job nobody declared a lease for - one claimed by hand, or re-fetched by a chunk
+        # rather than the one its task handed it - renews for the default
+        self.job.claim("worker-1", lease_seconds=60)
+
+        self.job.checkpoint(cursor={"after": "t1"})
+        self.assertAlmostEqual(
+            (self.job.lease_expires_on - timezone.now()).total_seconds(), DEFAULT_LEASE_SECONDS, delta=30
+        )
+
+        # and one a task stamped renews for as long as that task claimed it
+        self.job.lease_seconds = 1800
+        self.job.checkpoint(cursor={"after": "t2"})
+        self.assertAlmostEqual((self.job.lease_expires_on - timezone.now()).total_seconds(), 1800, delta=30)
+
+    def test_claim_reports_whether_it_started_a_run(self):
+        claimed = self.job.claim("worker-1")
+        self.assertTrue(claimed.new_run)
+        claimed.checkpoint(cursor={"after": "t1"})
+        claimed.release_lease()
+
+        # the continuation of a run in flight resumes it, so it isn't a new one - and the
+        # state the job was in before the claim can't say that: a run may have ended between
+        # reading it and claiming, which is what a duplicate delivery does
+        self.assertFalse(reload(self.job).claim("worker-2").new_run)
+
+        # nor is the retry of a failed one
+        self.job.refresh_from_db()
+        self.job.record_failure("boom")
+        self.assertFalse(reload(self.job).claim("worker-3").new_run)
+
+        # but the next claim of a job whose run ended is
+        self.job.refresh_from_db()
+        self.job.mark_complete()
+        self.job.release_lease()
+        self.assertTrue(reload(self.job).claim("worker-4").new_run)
+
+        # an unclaimed job is running nothing, so nothing about it is fresh
+        self.assertFalse(SyncJob.get_or_create_job(None, "test-sync", "flow-2").new_run)
+
+    def test_abort(self):
+        self.job.claim("worker-1")
+        self.job.checkpoint(cursor={"stage": "contacts"}, progress={"chunks": 2})
+
+        # aborting is done, with nothing left for the next run to resume from
+        self.assertTrue(self.job.abort(skipped=1))
+        self.assertJobState(self.job, cursor={}, progress={"chunks": 2, ABORTED: 1, "skipped": 1})
+
+        # the marker is the framework's own, so an app counter can't be mistaken for it
+        self.assertNotIn("aborted", reload(self.job).progress)
+
+        # unless the chunk knows where the next run should pick up
+        self.assertTrue(self.job.abort(cursor={"last_until": "t1"}))
+        self.assertJobState(self.job, cursor={"last_until": "t1"})
+
+    def test_back_off(self):
+        self.job.claim("worker-1")
+        modified_on = self.job.modified_on
+
+        # nothing to record, so nothing is written - the delay is all the chunk wanted
+        self.assertEqual(self.job.back_off(300), 300)
+        self.assertJobState(self.job, modified_on=modified_on, progress={})
+
+        self.assertEqual(self.job.back_off(300, lock_backoffs=1), 300)
+        self.assertJobState(self.job, progress={"lock_backoffs": 1})
+
+    def test_reset_cursor(self):
+        self.job.claim("worker-1", lease_seconds=600)
+        self.job.checkpoint(cursor={"after": "t1"}, progress={"chunks": 2})
+
+        # its worker owns the cursor while the lease is live, so the reset is refused
+        self.assertFalse(self.job.reset_cursor())
+        self.assertJobState(self.job, cursor={"after": "t1"})
+
+        drop_lease(self.job)
+        self.assertTrue(self.job.reset_cursor())
+
+        # only the position is dropped - the run it belongs to is left as it was
+        self.assertJobState(self.job, cursor={}, progress={"chunks": 2}, status=SyncJob.STATUS_RUNNING)
+
     def test_non_owner_cannot_mutate(self):
         self.job.claim("worker-1")
 
@@ -226,32 +330,14 @@ class SyncJobTest(TestCase):
         self.assertEqual(len(self.job.last_error), MAX_ERROR_LENGTH)
 
 
-def _make_task(chunks_to_run, finalize=None, fail_on_chunk=None):
-    """
-    Builds a chunked task that pretends to have the given number of chunks of work,
-    recording each chunk it runs.
-    """
-    ran = []
-
-    @chunked_task("test-sync", queue="testq", finalize=finalize, name=f"test.sync.{uuid.uuid4().hex}")
-    def sync_test(job):
-        chunk = job.cursor.get("chunk", 0)
-        if fail_on_chunk is not None and chunk == fail_on_chunk:
-            raise ValueError(f"failing on chunk {chunk}")
-
-        ran.append(chunk)
-        job.checkpoint(cursor={"chunk": chunk + 1}, progress=job.add_progress(chunks=1))
-        return chunk + 1 >= chunks_to_run
-
-    return sync_test, ran
-
-
-class ChunkedTaskTest(TestCase):
+class ChunkedTaskTest(SyncJobTestMixin, TestCase):
     def setUp(self):
+        super().setUp()
+
         self.job = SyncJob.get_or_create_job(None, "test-sync", "flow-1")
 
     def test_runs_chunks_to_completion(self):
-        task, ran = _make_task(chunks_to_run=3)
+        task, ran = make_task(chunks_to_run=3)
 
         with patch.object(task, "apply_async") as mock_continue:
             # each continuation is enqueued, not executed - drive them by hand as a worker would
@@ -263,14 +349,12 @@ class ChunkedTaskTest(TestCase):
 
         self.assertEqual(ran, [0, 1, 2])
 
-        job = SyncJob.objects.get(id=self.job.id)
-        self.assertEqual(job.status, SyncJob.STATUS_COMPLETE)
-        self.assertEqual(job.cursor, {"chunk": 3})
-        self.assertEqual(job.progress, {"chunks": 3})
-        self.assertIsNone(job.lease_owner)
+        self.assertJobState(
+            self.job, status=SyncJob.STATUS_COMPLETE, cursor={"chunk": 3}, progress={"chunks": 3}, lease_owner=None
+        )
 
     def test_trigger_against_live_lease_retries_after_expiry(self):
-        task, ran = _make_task(chunks_to_run=2)
+        task, ran = make_task(chunks_to_run=2)
 
         # a job someone else is running under a live lease - e.g. a redelivered chunk
         # whose original worker is still alive
@@ -284,43 +368,37 @@ class ChunkedTaskTest(TestCase):
         mock_continue.assert_not_called()
 
         # the job itself is untouched
-        current = SyncJob.objects.get(id=self.job.id)
-        self.assertEqual(current.lease_owner, "other-worker")
+        self.assertJobState(self.job, lease_owner="other-worker")
 
     def test_trigger_against_paused_job_skips(self):
-        task, ran = _make_task(chunks_to_run=2)
+        task, ran = make_task(chunks_to_run=2)
         SyncJob.objects.filter(id=self.job.id).update(status=SyncJob.STATUS_PAUSED)
 
-        with patch.object(task, "apply_async") as mock_continue:
-            task(self.job.id)  # no retry, no error
+        mock_continue = run_task(task, self.job.id)  # no retry, no error
 
         self.assertEqual(ran, [])
         mock_continue.assert_not_called()
 
     def test_finalize_runs_once_on_completion(self):
         finalized = []
-        task, ran = _make_task(chunks_to_run=1, finalize=lambda job: finalized.append(job.id))
+        task, ran = make_task(chunks_to_run=1, finalize=lambda job: finalized.append(job.id))
 
-        with patch.object(task, "apply_async"):
-            task(self.job.id)
+        run_task(task, self.job.id)
 
         self.assertEqual(finalized, [self.job.id])
-        job = SyncJob.objects.get(id=self.job.id)
-        self.assertFalse(job.needs_finalize)
-        self.assertIsNone(job.lease_owner)
+        self.assertJobState(self.job, needs_finalize=False, lease_owner=None)
 
     def test_crashed_finalize_is_retried_with_completed_runs_state(self):
         finalized = []
-        task, ran = _make_task(chunks_to_run=2, finalize=lambda job: finalized.append(dict(job.progress)))
+        task, ran = make_task(chunks_to_run=2, finalize=lambda job: finalized.append(dict(job.progress)))
 
         # simulate a worker that completed a run with real progress but died before finalizing
         self.job.claim("dead-worker")
         self.job.checkpoint(progress={"chunks": 7, "created": 700})
         self.job.mark_complete(needs_finalize=True)
-        SyncJob.objects.filter(id=self.job.id).update(lease_owner=None, lease_expires_on=None)
+        drop_lease(self.job)
 
-        with patch.object(task, "apply_async"):
-            task(self.job.id)
+        run_task(task, self.job.id)
 
         # the leftover finalization saw the completed run's progress, not the fresh run's
         # reset state, and ran before the new run's first chunk
@@ -328,29 +406,25 @@ class ChunkedTaskTest(TestCase):
         self.assertEqual(ran, [0])
 
     def test_chunk_failure_records_and_reraises(self):
-        task, ran = _make_task(chunks_to_run=3, fail_on_chunk=1)
+        task, ran = make_task(chunks_to_run=3, fail_on_chunk=1)
 
         with patch.object(task, "apply_async"):
             task(self.job.id)  # chunk 0 succeeds
             with self.assertRaises(ValueError):
                 task(self.job.id)  # chunk 1 fails
 
-        job = SyncJob.objects.get(id=self.job.id)
-        self.assertEqual(job.status, SyncJob.STATUS_FAILED)
-        self.assertEqual(job.consecutive_failures, 1)
-        self.assertIn("failing on chunk 1", job.last_error)
         # cursor still points at the failed chunk so a retry resumes there
-        self.assertEqual(job.cursor, {"chunk": 1})
-        self.assertIsNone(job.lease_owner)
+        job = self.assertJobState(
+            self.job, status=SyncJob.STATUS_FAILED, consecutive_failures=1, cursor={"chunk": 1}, lease_owner=None
+        )
+        self.assertIn("failing on chunk 1", job.last_error)
 
         # the failed job is claimable again and the retry resumes from the cursor
-        task2, ran2 = _make_task(chunks_to_run=3)
-        with patch.object(task2, "apply_async"):
-            task2(self.job.id)
-            task2(self.job.id)
+        task2, ran2 = make_task(chunks_to_run=3)
+        run_task(task2, self.job.id, times=2)
 
         self.assertEqual(ran2, [1, 2])
-        self.assertEqual(SyncJob.objects.get(id=self.job.id).status, SyncJob.STATUS_COMPLETE)
+        self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE)
 
     def test_failing_finalize_records_failure_and_is_retried(self):
         attempts = []
@@ -360,7 +434,7 @@ class ChunkedTaskTest(TestCase):
             if len(attempts) == 1:
                 raise ValueError("finalize blew up")
 
-        task, ran = _make_task(chunks_to_run=1, finalize=finalize)
+        task, ran = make_task(chunks_to_run=1, finalize=finalize)
 
         with patch.object(task, "apply_async"):
             with self.assertRaises(ValueError):
@@ -369,22 +443,20 @@ class ChunkedTaskTest(TestCase):
         # the work completed but the failed finalization is recorded and retryable:
         # failure counted, lease released so the retry needn't wait out its expiry,
         # and needs_finalize still set so the retry finalizes before anything else
-        job = SyncJob.objects.get(id=self.job.id)
-        self.assertEqual(job.status, SyncJob.STATUS_FAILED)
-        self.assertEqual(job.consecutive_failures, 1)
-        self.assertTrue(job.needs_finalize)
-        self.assertIsNone(job.lease_owner)
+        self.assertJobState(
+            self.job,
+            status=SyncJob.STATUS_FAILED,
+            consecutive_failures=1,
+            needs_finalize=True,
+            lease_owner=None,
+        )
 
-        with patch.object(task, "apply_async"):
-            task(self.job.id)
+        run_task(task, self.job.id)
 
         # the retry runs the leftover finalization first, then its own completion's -
         # at-least-once semantics, which is why finalize hooks must be idempotent
         self.assertEqual(len(attempts), 3)
-        job = SyncJob.objects.get(id=self.job.id)
-        self.assertFalse(job.needs_finalize)
-        self.assertEqual(job.status, SyncJob.STATUS_COMPLETE)
-        self.assertEqual(job.consecutive_failures, 0)
+        self.assertJobState(self.job, needs_finalize=False, status=SyncJob.STATUS_COMPLETE, consecutive_failures=0)
 
     def test_chunk_can_delay_continuation(self):
         delayed = []
@@ -404,19 +476,18 @@ class ChunkedTaskTest(TestCase):
             sync_backoff(self.job.id)
 
         self.assertEqual(delayed, [True])
-        self.assertEqual(SyncJob.objects.get(id=self.job.id).status, SyncJob.STATUS_COMPLETE)
+        self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE)
 
     def test_missing_job_is_skipped(self):
-        task, ran = _make_task(chunks_to_run=1)
+        task, ran = make_task(chunks_to_run=1)
 
-        with patch.object(task, "apply_async") as mock_continue:
-            task(-1)
+        mock_continue = run_task(task, -1)
 
         self.assertEqual(ran, [])
         mock_continue.assert_not_called()
 
     def test_continuation_of_paused_job_stops_quietly(self):
-        task, ran = _make_task(chunks_to_run=3)
+        task, ran = make_task(chunks_to_run=3)
 
         with patch.object(task, "apply_async") as mock_continue:
             task(self.job.id)
@@ -424,15 +495,15 @@ class ChunkedTaskTest(TestCase):
 
             # an operator pauses between chunks - the queued continuation stops the run,
             # without retrying against a lease that isn't there
-            self.assertTrue(SyncJob.objects.get(id=self.job.id).pause())
+            self.assertTrue(reload(self.job).pause())
             task(self.job.id)
 
         self.assertEqual(ran, [0])
         self.assertEqual(mock_continue.call_count, 1)
-        self.assertEqual(SyncJob.objects.get(id=self.job.id).status, SyncJob.STATUS_PAUSED)
+        self.assertJobState(self.job, status=SyncJob.STATUS_PAUSED)
 
     def test_continuation_after_force_resync_restarts(self):
-        task, ran = _make_task(chunks_to_run=4)
+        task, ran = make_task(chunks_to_run=4)
 
         with patch.object(task, "apply_async"):
             task(self.job.id)
@@ -441,26 +512,299 @@ class ChunkedTaskTest(TestCase):
 
             # the old cursor can't come back through the continuation that was already
             # queued when the resync was requested
-            self.assertTrue(SyncJob.objects.get(id=self.job.id).force_resync())
+            self.assertTrue(reload(self.job).force_resync())
             task(self.job.id)
 
         self.assertEqual(ran, [0, 1, 0])
-        job = SyncJob.objects.get(id=self.job.id)
-        self.assertEqual(job.cursor, {"chunk": 1})
-        self.assertEqual(job.progress, {"chunks": 1})
+        self.assertJobState(self.job, cursor={"chunk": 1}, progress={"chunks": 1})
+
+
+class ChunkedTaskStateTest(SyncJobTestMixin, TestCase):
+    """
+    What the framework tells a chunk about the claim it is running under, and what it does
+    with what the chunk tells it back.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.job = SyncJob.get_or_create_job(None, "test-sync", "flow-1")
+
+    def test_chunk_checkpoints_with_the_declared_lease(self):
+        renewals = []
+
+        @chunked_task("test-sync", queue="testq", lease_seconds=1800, name=f"test.sync.{uuid.uuid4().hex}")
+        def sync_leases(job):
+            job.checkpoint(cursor={"chunk": 1})
+            renewals.append(job.lease_expires_on)
+
+            # a chunk that knows better can still say so
+            job.checkpoint(lease_seconds=60)
+            renewals.append(job.lease_expires_on)
+            return True
+
+        run_task(sync_leases, self.job.id)
+
+        now = timezone.now()
+        self.assertAlmostEqual((renewals[0] - now).total_seconds(), 1800, delta=30)
+        self.assertAlmostEqual((renewals[1] - now).total_seconds(), 60, delta=30)
+
+    def test_new_run_marks_the_first_chunk_of_a_run(self):
+        seen = []
+
+        @chunked_task("test-sync", queue="testq", name=f"test.sync.{uuid.uuid4().hex}")
+        def sync_runs(job):
+            seen.append(job.new_run)
+            chunk = job.cursor.get("chunk", 0)
+            job.checkpoint(cursor={"chunk": chunk + 1})
+            return chunk >= 1
+
+        # a job that has never run starts one, and its continuation resumes that same run
+        self.assertEqual(run_to_completion(sync_runs, self.job.id), 2)
+        self.assertEqual(seen, [True, False])
+
+        # the next claim of a completed job starts a fresh run
+        seen.clear()
+        run_task(sync_runs, self.job.id)
+        self.assertEqual(seen, [True])
+
+        # while a failed run is retried rather than restarted
+        seen.clear()
+        SyncJob.objects.filter(id=self.job.id).update(status=SyncJob.STATUS_FAILED)
+        run_task(sync_runs, self.job.id)
+        self.assertEqual(seen, [False])
+
+    def test_aborted_run_completes_without_finalizing(self):
+        finalized = []
+
+        @chunked_task(
+            "test-sync", queue="testq", finalize=lambda job: finalized.append(job.id), name=f"test.{uuid.uuid4().hex}"
+        )
+        def sync_aborts(job):
+            return job.abort(skipped=1)
+
+        run_task(sync_aborts, self.job.id)
+
+        # there is nothing for finalization to report on, but the run is still finished and
+        # its lease released, and nothing is left over for the next one
+        self.assertEqual(finalized, [])
+        self.assertJobState(
+            self.job,
+            status=SyncJob.STATUS_COMPLETE,
+            cursor={},
+            progress={ABORTED: 1, "skipped": 1},
+            needs_finalize=False,
+            lease_owner=None,
+        )
+
+    def test_leftover_finalize_of_an_aborted_run_is_skipped(self):
+        finalized = []
+        task, ran = make_task(chunks_to_run=1, finalize=lambda job: finalized.append(job.id))
+
+        # a worker that aborted a run and died before clearing its finalize flag
+        self.job.claim("dead-worker")
+        self.job.checkpoint(progress={ABORTED: 1})
+        self.job.mark_complete(needs_finalize=True)
+        drop_lease(self.job)
+
+        run_task(task, self.job.id)
+
+        # the leftover finalization went with the run it belonged to, this run's still ran
+        self.assertEqual(finalized, [self.job.id])
+        self.assertEqual(ran, [0])
+
+    def test_one_task_per_job_type(self):
+        make_task(chunks_to_run=1)
+
+        # two tasks for a type would each drive the other's jobs, on whatever queue and
+        # lease they happened to declare
+        with self.assertRaises(ImproperlyConfigured):
+
+            @chunked_task("test-sync", queue="testq", name=f"test.sync.{uuid.uuid4().hex}")
+            def sync_again(job):
+                return True
+
+    def test_chunk_can_back_off_and_record_why(self):
+        @chunked_task("test-sync", queue="testq", name=f"test.sync.{uuid.uuid4().hex}")
+        def sync_blocked(job):
+            if job.progress.get("lock_backoffs"):
+                job.checkpoint(cursor={"chunk": 1})
+                return True
+
+            return job.back_off(300, lock_backoffs=1)
+
+        mock_continue = run_task(sync_blocked, self.job.id)
+
+        mock_continue.assert_called_once_with((self.job.id,), queue="testq", countdown=300)
+        self.assertJobState(self.job, progress={"lock_backoffs": 1}, cursor={})
+
+        run_task(sync_blocked, self.job.id)
+        self.assertJobState(self.job, status=SyncJob.STATUS_COMPLETE, cursor={"chunk": 1})
+
+
+class DispatchTest(SyncJobTestMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.job = SyncJob.get_or_create_job(None, "test-sync", "flow-1")
+
+        # the task this job type is run by, i.e. what the registry resolves for it - and
+        # with it the lease everything here is measured against
+        self.task, _ = make_task(chunks_to_run=2)
+
+    def test_enqueue_routes_to_the_job_types_task(self):
+        task, ran = make_task(chunks_to_run=1, queue="slowq")
+        self.assertEqual(JOB_TASKS["test-sync"], task)
+
+        with patch.object(task, "apply_async") as mock_enqueue:
+            enqueue(self.job)
+            enqueue(self.job, countdown=300)
+
+        # the job knows its type, and the queue comes with the task that type is run by
+        self.assertEqual(mock_enqueue.call_args_list[0][0], ((self.job.id,),))
+        self.assertEqual(mock_enqueue.call_args_list[0][1], dict(queue="slowq"))
+        self.assertEqual(mock_enqueue.call_args_list[1][1], dict(queue="slowq", countdown=300))
+
+    def test_in_flight_under_a_live_lease(self):
+        self.assertFalse(in_flight(self.job, timezone.now()))
+
+        # a chunk is being worked on, whatever state the row is otherwise in
+        hold_lease(self.job)
+        self.assertTrue(in_flight(self.job, timezone.now()))
+
+    def test_in_flight_between_chunks(self):
+        SyncJob.objects.filter(id=self.job.id).update(status=SyncJob.STATUS_RUNNING)
+
+        # the lease is released between continuations, so a moving run looks idle from here
+        self.assertTrue(in_flight(reload(self.job), timezone.now()))
+
+        # but a run that stopped checkpointing is deliberately not in flight - nudging it is
+        # how a chain that died without recording a failure gets picked back up
+        job = make_stale(self.job, 2 * DEFAULT_LEASE_SECONDS + 60)
+        self.assertFalse(in_flight(job, timezone.now()))
+
+    def test_in_flight_of_a_pending_job(self):
+        now = timezone.now()
+
+        # a job nobody has claimed is only in flight for callers whose enqueue records the
+        # nudge on the row, i.e. where a fresh modified_on means a message is on the queue
+        self.assertFalse(in_flight(self.job, now))
+        self.assertTrue(in_flight(self.job, now, include_pending=True))
+
+        job = make_stale(self.job, 2 * DEFAULT_LEASE_SECONDS + 60)
+        self.assertFalse(in_flight(job, now, include_pending=True))
+
+    def test_in_flight_of_an_unregistered_job_type(self):
+        job = SyncJob.get_or_create_job(None, "no-such-task", "flow-1")
+        SyncJob.objects.filter(id=job.id).update(status=SyncJob.STATUS_RUNNING)
+
+        # nothing declares how long its chunks take, so the default lease is what it gets
+        self.assertTrue(in_flight(reload(job), timezone.now()))
+        self.assertFalse(in_flight(make_stale(job, 2 * DEFAULT_LEASE_SECONDS + 60), timezone.now()))
+
+    def test_is_due_measures_the_cadence_from_the_last_start(self):
+        now = timezone.now()
+        hourly = timedelta(hours=1)
+
+        # a job that has never run is due at any cadence
+        self.assertTrue(is_due(self.job, now, interval=hourly))
+
+        job = end_run(self.job, started_on=now - timedelta(minutes=30), ended_on=now - timedelta(minutes=5))
+        self.assertFalse(is_due(job, now, interval=hourly))
+
+        # no cadence asked for means any run that isn't moving is due
+        self.assertTrue(is_due(job, now))
+
+        job = end_run(self.job, started_on=now - timedelta(hours=2), ended_on=now - timedelta(minutes=5))
+        self.assertTrue(is_due(job, now, interval=hourly))
+
+        # a run that ended without ever starting - an abort, say - falls back to its end
+        job = end_run(self.job, started_on=None, ended_on=now - timedelta(minutes=5))
+        self.assertFalse(is_due(job, now, interval=hourly))
+
+    def test_is_due_waits_out_the_failure_backoff(self):
+        now = timezone.now()
+        backoff = Backoff(base=timedelta(minutes=20), cap=timedelta(hours=2), max_doublings=3)
+
+        job = end_run(self.job, status=SyncJob.STATUS_FAILED, ended_on=now - timedelta(minutes=5), failures=1)
+        self.assertTrue(is_due(job, now))  # nobody asked for a backoff
+        self.assertFalse(is_due(job, now, backoff=backoff))
+
+        job = end_run(self.job, status=SyncJob.STATUS_FAILED, ended_on=now - timedelta(minutes=25), failures=1)
+        self.assertTrue(is_due(job, now, backoff=backoff))
+
+        # each further failure doubles the wait - 20, 40, 80 minutes ...
+        job = end_run(self.job, status=SyncJob.STATUS_FAILED, ended_on=now - timedelta(minutes=25), failures=3)
+        self.assertFalse(is_due(job, now, backoff=backoff))
+
+        # ... up to the cap, however long the streak
+        job = end_run(self.job, status=SyncJob.STATUS_FAILED, ended_on=now - timedelta(hours=1), failures=9)
+        self.assertFalse(is_due(job, now, backoff=backoff))
+
+        job = end_run(self.job, status=SyncJob.STATUS_FAILED, ended_on=now - timedelta(hours=3), failures=9)
+        self.assertTrue(is_due(job, now, backoff=backoff))
+
+    def test_failure_backoff_never_outpaces_the_cadence(self):
+        # a run long enough to outlast its own cadence keeps the cadence open from then on,
+        # so the backoff is what has to hold a failing job back - the ladder's early rungs
+        # must not retry it faster than it would run when healthy
+        now = timezone.now()
+        daily = timedelta(hours=24)
+        backoff = Backoff(base=timedelta(minutes=20), cap=timedelta(days=7), max_doublings=10)
+
+        job = end_run(
+            self.job,
+            status=SyncJob.STATUS_FAILED,
+            started_on=now - timedelta(days=3),
+            ended_on=now - timedelta(hours=2),
+            failures=1,
+        )
+        self.assertFalse(is_due(job, now, interval=daily, backoff=backoff))
+
+        # and once the cadence itself is up, it is due
+        job = end_run(
+            self.job,
+            status=SyncJob.STATUS_FAILED,
+            started_on=now - timedelta(days=3),
+            ended_on=now - timedelta(days=2),
+            failures=1,
+        )
+        self.assertTrue(is_due(job, now, interval=daily, backoff=backoff))
+
+        # a streak whose ladder climbs past the cadence stretches the wait beyond it
+        job = end_run(
+            self.job,
+            status=SyncJob.STATUS_FAILED,
+            started_on=now - timedelta(days=3),
+            ended_on=now - timedelta(days=2),
+            failures=9,  # 20 minutes doubled eight times, i.e. more than three days
+        )
+        self.assertFalse(is_due(job, now, interval=daily, backoff=backoff))
+
+    def test_is_due_nudges_a_run_that_never_ended(self):
+        # a chain that died without recording a failure left no end to schedule from, and
+        # the run it was still in the middle of says nothing about when the next one is due
+        now = timezone.now()
+        SyncJob.objects.filter(id=self.job.id).update(
+            status=SyncJob.STATUS_RUNNING, started_on=now - timedelta(minutes=5), ended_on=None
+        )
+
+        job = make_stale(self.job, 2 * DEFAULT_LEASE_SECONDS + 60)
+        self.assertTrue(is_due(job, now, interval=timedelta(hours=24)))
+
+    def test_is_due_leaves_paused_and_moving_jobs_alone(self):
+        SyncJob.objects.filter(id=self.job.id).update(status=SyncJob.STATUS_PAUSED)
+        self.assertFalse(is_due(reload(self.job), timezone.now()))
+
+        SyncJob.objects.filter(id=self.job.id).update(status=SyncJob.STATUS_RUNNING)
+        self.assertFalse(is_due(reload(self.job), timezone.now()))
 
 
 class SyncJobQueriesTest(TestCase):
     def setUp(self):
+        super().setUp()
+
         self.job = SyncJob.get_or_create_job(None, "test-sync", "flow-1")
-
-    def expire_lease(self, job, seconds_ago):
-        SyncJob.objects.filter(id=job.id).update(lease_expires_on=timezone.now() - timedelta(seconds=seconds_ago))
-        job.refresh_from_db()
-
-    def set_modified(self, job, seconds_ago):
-        SyncJob.objects.filter(id=job.id).update(modified_on=timezone.now() - timedelta(seconds=seconds_ago))
-        job.refresh_from_db()
 
     def test_stale_respects_grace(self):
         # a job whose worker is still renewing its lease is working, not stale
@@ -468,7 +812,7 @@ class SyncJobQueriesTest(TestCase):
         self.assertEqual(list(SyncJob.objects.stale()), [])
 
         # a lease that expired moments ago may still be taken over by a redelivered chunk
-        self.expire_lease(self.job, 60)
+        expire_lease(self.job, 60)
         self.assertEqual(list(SyncJob.objects.stale()), [])
         self.assertEqual(list(SyncJob.objects.stale(grace_seconds=30)), [self.job])
 
@@ -476,7 +820,7 @@ class SyncJobQueriesTest(TestCase):
         self.assertEqual(list(SyncJob.objects.stale(grace_seconds=61)), [])
         self.assertEqual(list(SyncJob.objects.stale(grace_seconds=59)), [self.job])
 
-        self.expire_lease(self.job, 60 * 30)
+        expire_lease(self.job, 60 * 30)
         self.assertEqual(list(SyncJob.objects.stale()), [self.job])
 
     def test_stale_covers_lost_continuations(self):
@@ -486,14 +830,14 @@ class SyncJobQueriesTest(TestCase):
         self.assertEqual(list(SyncJob.objects.stale()), [])
 
         # but if that continuation never arrives the run is just as abandoned
-        self.set_modified(self.job, 60 * 30)
+        make_stale(self.job, 60 * 30)
         self.assertEqual(list(SyncJob.objects.stale()), [self.job])
 
     def test_stale_ignores_ended_runs(self):
         self.job.claim("worker-1")
         self.job.record_failure("boom")
-        self.expire_lease(self.job, 60 * 30)
-        self.set_modified(self.job, 60 * 30)
+        expire_lease(self.job, 60 * 30)
+        make_stale(self.job, 60 * 30)
 
         self.assertEqual(list(SyncJob.objects.stale()), [])
 
@@ -524,13 +868,11 @@ class SyncJobQueriesTest(TestCase):
         self.assertEqual(len(self.job.error_summary), MAX_ERROR_SUMMARY_LENGTH)
 
 
-class OperatorActionsTest(TestCase):
+class OperatorActionsTest(SyncJobTestMixin, TestCase):
     def setUp(self):
-        self.job = SyncJob.get_or_create_job(None, "test-sync", "flow-1")
+        super().setUp()
 
-    def expire_lease(self, job):
-        SyncJob.objects.filter(id=job.id).update(lease_expires_on=timezone.now() - timedelta(seconds=1))
-        job.refresh_from_db()
+        self.job = SyncJob.get_or_create_job(None, "test-sync", "flow-1")
 
     def test_pause_refused_under_live_lease(self):
         self.job.claim("worker-1", lease_seconds=600)
@@ -554,7 +896,7 @@ class OperatorActionsTest(TestCase):
 
     def test_pause_allowed_once_lease_expires(self):
         self.job.claim("worker-1")
-        self.expire_lease(self.job)
+        expire_lease(self.job)
 
         self.assertTrue(self.job.pause())
 
@@ -568,7 +910,7 @@ class OperatorActionsTest(TestCase):
     def test_paused_job_survives_its_worker(self):
         # a worker whose lease lapsed is still alive and still finishing its chunk
         self.job.claim("worker-1")
-        self.expire_lease(self.job)
+        expire_lease(self.job)
         self.assertTrue(self.job.pause())
 
         # its writes must not take the job back out of the paused state


### PR DESCRIPTION
Consolidates the plumbing that six chunked task families were each carrying privately — a simplification review found ~240 lines of dispatcher/lock/abort logic duplicated 2–3 ways, already diverging (a duplicate-message bug was fixed in only one copy).

**New framework surface (`ureport/syncjobs/`):**
- `dispatch.py` — a job-type→task registry (guarded against conflicting re-registration), `enqueue(job)` that routes to the task's declared queue, and one shared `in_flight()` / `is_due()` with an explicit failure-backoff type, replacing three diverging app copies.
- `locks.py` — the non-blocking acquire / release-in-finally lock context manager three modules each implemented.
- `testing.py` — shared test helpers (task driving, job state assertions, lease manipulation), replacing eight private definitions of the same arrange code across the test files.
- Model/decorator additions: `checkpoint()` defaults to the claiming task's declared lease (removing 22 hand-repeated arguments), `job.abort()` with framework-level skip of finalization (reserved `__aborted` sentinel, logged), `job.back_off()`, `job.new_run` computed atomically inside `claim()`, and `SyncJob.reset_cursor()`.

**Two deliberate behavior changes**, both review-driven:
- Dispatch cadence anchors on when the last run **started** (falling back to ended) — an end-anchored gate demonstrably starves any run longer than a fifth of its cadence into skipping cycles. The failure backoff keeps its floor: it can never retry faster than the job's own cadence (a state-sweep in review caught the regression where the split anchors let a broken daily job retry on a minutes ladder).
- A run that died without recording a failure (ended-on null) is nudged as soon as its staleness window passes, regardless of cadence.

Both are pinned by mutation-checked tests through the real poll cadences, with production-shaped fixtures.

`polls/sync.py` and `contacts/sync.py` are ported to the shared helpers; the three open conversion PRs (#1380, #1381, #1382) are rebased onto this and shrunk accordingly. Net today: three concepts go from three definitions to one; 316 tests green.
