### PR TITLE
Add sync jobs to the superuser admin menus

### DIFF
--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2019-05-15 20:27+0000\n"
 "Last-Translator: Abraham Okiror <okiroribra@gmail.com>, 2019\n"
 "Language-Team: Arabic (https://www.transifex.com/rapidpro/teams/226/ar/)\n"
@@ -752,6 +752,11 @@ msgstr "المؤسسات"
 
 msgid "Images"
 msgstr "الصور"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "الأعمال"
 
 msgid "About"
 msgstr "نبذة عن "

--- a/locale/bg/LC_MESSAGES/django.po
+++ b/locale/bg/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2019-05-15 20:27+0000\n"
 "Last-Translator: Stanislav Dodov <stanislav.dodov@gmail.com>, 2020\n"
 "Language-Team: Bulgarian (https://www.transifex.com/rapidpro/teams/226/bg/)\n"
@@ -753,6 +753,11 @@ msgstr "Организации"
 
 msgid "Images"
 msgstr "Изображения"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Заети длъжности"
 
 msgid "About"
 msgstr "За нас"

--- a/locale/bn/LC_MESSAGES/django.po
+++ b/locale/bn/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2019-05-15 20:27+0000\n"
 "Last-Translator: Syeara Koomkoom, 2019\n"
 "Language-Team: Bengali (https://www.transifex.com/rapidpro/teams/226/bn/)\n"
@@ -759,6 +759,11 @@ msgstr "অরগ "
 
 msgid "Images"
 msgstr "ছবি গুলো "
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "কাজ গুলো"
 
 msgid "About"
 msgstr "সম্পর্কিত "

--- a/locale/bs/LC_MESSAGES/django.po
+++ b/locale/bs/LC_MESSAGES/django.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2019-05-15 20:27+0000\n"
 "Last-Translator: Benjamin Omerbegović <bomerbegovic@unicef.org>, 2020\n"
 "Language-Team: Bosnian (https://www.transifex.com/rapidpro/teams/226/bs/)\n"
@@ -843,6 +843,11 @@ msgstr "Orgs"
 
 msgid "Images"
 msgstr "Slike"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Poslovi"
 
 msgid "About"
 msgstr "O nama"

--- a/locale/cs/LC_MESSAGES/django.po
+++ b/locale/cs/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2021-03-30 14:28+0000\n"
 "Last-Translator: Jiří Podhorecký <jirka.p@volny.cz>, 2024\n"
 "Language-Team: Czech (https://app.transifex.com/rapidpro/teams/226/cs/)\n"
@@ -756,6 +756,11 @@ msgstr "Organizace"
 
 msgid "Images"
 msgstr "Obrázky"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Úlohy"
 
 msgid "About"
 msgstr "O ..."

--- a/locale/el/LC_MESSAGES/django.po
+++ b/locale/el/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2021-03-30 14:28+0000\n"
 "Last-Translator: Artemis Papakostouli, 2022\n"
 "Language-Team: Greek (https://www.transifex.com/rapidpro/teams/226/el/)\n"
@@ -750,6 +750,11 @@ msgstr "Οργ."
 
 msgid "Images"
 msgstr "Εικόνες"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Θέσεις εργασίας"
 
 msgid "About"
 msgstr "Σχετικά με εμάς"

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -713,6 +713,9 @@ msgid "Orgs"
 msgstr ""
 
 msgid "Images"
+msgstr ""
+
+msgid "Sync Jobs"
 msgstr ""
 
 msgid "About"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2021-03-30 14:28+0000\n"
 "Last-Translator: WILDNEY RAPHAEL SILVA CAVALCANTE, 2025\n"
 "Language-Team: Spanish (https://app.transifex.com/rapidpro/teams/226/es/)\n"
@@ -751,6 +751,11 @@ msgstr "Orgs"
 
 msgid "Images"
 msgstr "Imágenes"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Empleos"
 
 msgid "About"
 msgstr "Acerca"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2021-03-30 14:28+0000\n"
 "Last-Translator: Juan Arguello Yepez, 2022\n"
 "Language-Team: French (https://www.transifex.com/rapidpro/teams/226/fr/)\n"
@@ -758,6 +758,11 @@ msgstr "Orgs"
 
 msgid "Images"
 msgstr "Images"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Emplois"
 
 msgid "About"
 msgstr "À Propos"

--- a/locale/hr_HR/LC_MESSAGES/django.po
+++ b/locale/hr_HR/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2019-05-15 20:27+0000\n"
 "Last-Translator: Marijana Muhic <mmuhic@unicef.org>, 2021\n"
 "Language-Team: Croatian (Croatia) (https://www.transifex.com/rapidpro/teams/226/hr_HR/)\n"
@@ -763,6 +763,11 @@ msgstr "Orgs"
 
 msgid "Images"
 msgstr "Slike"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Poslovi"
 
 msgid "About"
 msgstr "O nama"

--- a/locale/id/LC_MESSAGES/django.po
+++ b/locale/id/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: UReport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2016-10-26 13:08+0000\n"
 "Last-Translator: I made suwancita <isuwancita@gmail.com>\n"
 "Language-Team: Indonesian (http://www.transifex.com/rapidpro/ureport/language/id/)\n"
@@ -785,6 +785,11 @@ msgstr "Orgs"
 
 msgid "Images"
 msgstr "Gambar"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Pekerjaan"
 
 msgid "About"
 msgstr "Tentang Kami"

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2019-05-15 20:27+0000\n"
 "Last-Translator: Chiara Saturnino <csaturnino@unicef.org>, 2019\n"
 "Language-Team: Italian (https://www.transifex.com/rapidpro/teams/226/it/)\n"
@@ -756,6 +756,11 @@ msgstr "Organizzazioni"
 
 msgid "Images"
 msgstr "Immagini"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Opportunità di lavoro"
 
 msgid "About"
 msgstr "Chi siamo"

--- a/locale/kk/LC_MESSAGES/django.po
+++ b/locale/kk/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2021-03-30 14:28+0000\n"
 "Last-Translator: Askhat Makitov, 2024\n"
 "Language-Team: Kazakh (https://app.transifex.com/rapidpro/teams/226/kk/)\n"
@@ -724,6 +724,11 @@ msgstr "Ұйымдар"
 
 msgid "Images"
 msgstr "Суреттер"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Жұмыстар"
 
 msgid "About"
 msgstr "Туралы"

--- a/locale/mk_MK/LC_MESSAGES/django.po
+++ b/locale/mk_MK/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2019-05-15 20:27+0000\n"
 "Last-Translator: Nathallia Salvador <nathallia.salvador@ilhasoft.com.br>, 2021\n"
 "Language-Team: Macedonian (Macedonia) (https://www.transifex.com/rapidpro/teams/226/mk_MK/)\n"
@@ -759,6 +759,11 @@ msgstr "Организации"
 
 msgid "Images"
 msgstr "Слики"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Работни места"
 
 msgid "About"
 msgstr "За нас"

--- a/locale/my/LC_MESSAGES/django.po
+++ b/locale/my/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2019-05-15 20:27+0000\n"
 "Last-Translator: Sandar Linn <slinn@unicef.org>, 2019\n"
 "Language-Team: Burmese (https://www.transifex.com/rapidpro/teams/226/my/)\n"
@@ -720,6 +720,9 @@ msgstr ""
 
 msgid "Images"
 msgstr "ဓါတ်ပုံများ"
+
+msgid "Sync Jobs"
+msgstr ""
 
 msgid "About"
 msgstr "U-Report အကြောင်း"

--- a/locale/no/LC_MESSAGES/django.po
+++ b/locale/no/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2019-05-15 20:27+0000\n"
 "Last-Translator: Nathallia Salvador <nathallia.salvador@ilhasoft.com.br>, 2020\n"
 "Language-Team: Norwegian (https://www.transifex.com/rapidpro/teams/226/no/)\n"
@@ -753,6 +753,11 @@ msgstr "Organisasjoner"
 
 msgid "Images"
 msgstr "Bilder"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Jobber"
 
 msgid "About"
 msgstr "Om oss"

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2021-03-30 14:28+0000\n"
 "Last-Translator: Rodolfo Pedro, 2023\n"
 "Language-Team: Portuguese (https://app.transifex.com/rapidpro/teams/226/pt/)\n"
@@ -753,6 +753,11 @@ msgstr "Organizações"
 
 msgid "Images"
 msgstr "Imagens"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Empregos"
 
 msgid "About"
 msgstr "Sobre Nós"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2019-05-15 20:27+0000\n"
 "Last-Translator: Viração Educomunicação <comunicacao@viracao.org>, 2019\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/rapidpro/teams/226/pt_BR/)\n"
@@ -761,6 +761,11 @@ msgstr "Organizações"
 
 msgid "Images"
 msgstr "Imagens"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Empregos"
 
 msgid "About"
 msgstr "Sobre"

--- a/locale/ro/LC_MESSAGES/django.po
+++ b/locale/ro/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2019-05-15 20:27+0000\n"
 "Last-Translator: AIex Petrov <alexandrupetrov@gmail.com>, 2019\n"
 "Language-Team: Romanian (https://www.transifex.com/rapidpro/teams/226/ro/)\n"
@@ -761,6 +761,11 @@ msgstr "Organizații"
 
 msgid "Images"
 msgstr "Imagini"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Oferte de muncă"
 
 msgid "About"
 msgstr "Despre noi"

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2019-05-15 20:27+0000\n"
 "Last-Translator: Mirbek Tursunbekov, 2021\n"
 "Language-Team: Russian (https://www.transifex.com/rapidpro/teams/226/ru/)\n"
@@ -758,6 +758,11 @@ msgstr "Организации"
 
 msgid "Images"
 msgstr "Изображения"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Работы"
 
 msgid "About"
 msgstr "О нас"

--- a/locale/sl/LC_MESSAGES/django.po
+++ b/locale/sl/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2021-03-30 14:28+0000\n"
 "Last-Translator: Tjaša Jazbinšek, 2023\n"
 "Language-Team: Slovenian (https://app.transifex.com/rapidpro/teams/226/sl/)\n"
@@ -754,6 +754,11 @@ msgstr "Organizacije"
 
 msgid "Images"
 msgstr "Slike"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Prosta delovna mesta"
 
 msgid "About"
 msgstr "O nas"

--- a/locale/sr_Latn/LC_MESSAGES/django.po
+++ b/locale/sr_Latn/LC_MESSAGES/django.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: UReport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2019-02-04 17:54+0000\n"
 "Last-Translator: Tales Souza <tales@ilhasoft.com.br>\n"
 "Language-Team: Serbian (Latin) (Serbia) (http://www.transifex.com/rapidpro/ureport/language/sr_RS%40latin/)\n"
@@ -794,6 +794,11 @@ msgstr "Orgs"
 
 msgid "Images"
 msgstr "Slike"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Poslovi"
 
 msgid "About"
 msgstr "O nama"

--- a/locale/sr_RS@latin/LC_MESSAGES/django.po
+++ b/locale/sr_RS@latin/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2021-03-30 14:28+0000\n"
 "Last-Translator: Marko Mitrovic <mmitrovic@unicef.org>, 2023\n"
 "Language-Team: Serbian (Latin) (Serbia) (https://app.transifex.com/rapidpro/teams/226/sr_RS@latin/)\n"
@@ -749,6 +749,11 @@ msgstr "Orgs"
 
 msgid "Images"
 msgstr "Slike"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Poslovi"
 
 msgid "About"
 msgstr "O nama"

--- a/locale/sv_SE/LC_MESSAGES/django.po
+++ b/locale/sv_SE/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2019-05-15 20:27+0000\n"
 "Last-Translator: Malin Åkerlöf <malin.akerlof@unicef.se>, 2021\n"
 "Language-Team: Swedish (Sweden) (https://www.transifex.com/rapidpro/teams/226/sv_SE/)\n"
@@ -750,6 +750,11 @@ msgstr "Organisationer"
 
 msgid "Images"
 msgstr "Bilder"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Jobb"
 
 msgid "About"
 msgstr "Om oss"

--- a/locale/th/LC_MESSAGES/django.po
+++ b/locale/th/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2021-03-30 14:28+0000\n"
 "Last-Translator: M. S., 2023\n"
 "Language-Team: Thai (https://www.transifex.com/rapidpro/teams/226/th/)\n"
@@ -753,6 +753,11 @@ msgstr "องค์กร"
 
 msgid "Images"
 msgstr "รูปภาพ"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "ตำแหน่งงาน"
 
 msgid "About"
 msgstr "รู้จักยูรีพอร์ต"

--- a/locale/uk/LC_MESSAGES/django.po
+++ b/locale/uk/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2021-03-30 14:28+0000\n"
 "Last-Translator: Ellen Gonçalves <ellen.goncalves@weni.ai>, 2022\n"
 "Language-Team: Ukrainian (https://www.transifex.com/rapidpro/teams/226/uk/)\n"
@@ -758,6 +758,11 @@ msgstr "Організації"
 
 msgid "Images"
 msgstr "Зображення"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Вакансії"
 
 msgid "About"
 msgstr "Про нас"

--- a/locale/uz/LC_MESSAGES/django.po
+++ b/locale/uz/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2019-05-15 20:27+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -751,6 +751,11 @@ msgstr "Tashkr"
 
 msgid "Images"
 msgstr "Suratlar"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Ish o'rinlari"
 
 msgid "About"
 msgstr "Haqida"

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: UReport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 10:05+0000\n"
+"POT-Creation-Date: 2026-08-26 16:40+0000\n"
 "PO-Revision-Date: 2017-11-07 07:04+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -782,6 +782,11 @@ msgstr "Tổ chức"
 
 msgid "Images"
 msgstr "Hình ảnh"
+
+#, fuzzy
+#| msgid "Jobs"
+msgid "Sync Jobs"
+msgstr "Công việc"
 
 msgid "About"
 msgstr "Thông tin"

--- a/templates/base_admin_dashboard.html
+++ b/templates/base_admin_dashboard.html
@@ -288,6 +288,14 @@
                                                     <span class="menu-link-title">{% trans "Images" %}</span>
                                                 </a>
                                             </li>
+                                            <li>
+                                                <a href="{% url 'syncjobs.syncjob_list' %}">
+                                                    <span class="icon">
+                                                        <img src="{{ STATIC_URL }}img/icons/settings_icon.png" alt="">
+                                                    </span>
+                                                    <span class="menu-link-title">{% trans "Sync Jobs" %}</span>
+                                                </a>
+                                            </li>
                                         {% endif %}
                                     </ul>
                                 </aside>

--- a/templates/frame.html
+++ b/templates/frame.html
@@ -159,6 +159,9 @@
                                             <li>
                                                 <a href="{% url 'dashblocks.dashblocktype_list' %}">{% trans "Content Types" %}</a>
                                             </li>
+                                            <li>
+                                                <a href="{% url 'syncjobs.syncjob_list' %}">{% trans "Sync Jobs" %}</a>
+                                            </li>
                                             {% if request.user.is_superuser or org_perms.assets.image_list %}
                                                 <li>
                                                     <a href="{% url 'assets.image_list' %}">{% trans "Images" %}</a>

--- a/ureport/syncjobs/tests.py
+++ b/ureport/syncjobs/tests.py
@@ -1215,3 +1215,18 @@ class SyncJobCRUDLTest(UreportTest):
             reverse("syncjobs.syncjob_resume", args=[self.job.id]), SERVER_NAME="uganda.ureport.io", follow=True
         )
         self.assertContains(response, "isn&#x27;t paused")
+
+    def test_admin_menu_link_is_superuser_only(self):
+        menu_page_url = reverse("polls.poll_list")
+        list_url = reverse("syncjobs.syncjob_list")
+
+        # the link sits in the superuser-only part of the admin menu, so org admins never see it
+        self.login(self.admin)
+        response = self.client.get(menu_page_url, SERVER_NAME="uganda.ureport.io")
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, list_url)
+
+        self.login(self.superuser)
+        response = self.client.get(menu_page_url, SERVER_NAME="uganda.ureport.io")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, list_url)


### PR DESCRIPTION
Makes the sync job management list (added in #1378 at /manage/syncjob) reachable from the navigation instead of by URL only:

- a **Sync Jobs** entry in the admin site's left menu, inside the existing superuser-only section alongside Orgs / Users / Content Types / Images
- the same entry in the public-site admin navbar's superuser Configuration dropdown, mirroring how those lists are exposed there

Both placements are gated on superuser, matching the view's own permission gating. Includes a test asserting the menu link renders for a superuser and not for an org admin, plus the regenerated locale files for the new menu string.