### PR TITLE
Allow postgres and valkey hosts in dev settings to come from the environment

### DIFF
--- a/ureport/polls/tests.py
+++ b/ureport/polls/tests.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone as tzone
 
 from mock import Mock, patch
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User
 from django.core.cache import cache
@@ -1161,7 +1162,7 @@ class PollTest(UreportTest):
             CACHES={
                 "default": {
                     "BACKEND": "django_valkey.cache.ValkeyCache",
-                    "LOCATION": "redis://127.0.0.1:6379/1",
+                    "LOCATION": "redis://%s:6379/1" % getattr(settings, "VALKEY_HOST", "localhost"),
                 }
             }
         ):

--- a/ureport/settings.py.postgres
+++ b/ureport/settings.py.postgres
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import os
+
 from ureport.settings_common import *
 
 # INSTALLED_APPS = INSTALLED_APPS + ('debug_toolbar.apps.DebugToolbarConfig',)
@@ -46,13 +48,15 @@ LOGGING['loggers']['celery.worker'] = {
 #     'compressor.finders.CompressorFinder',
 # )
 
+# the backing services default to localhost; set POSTGRES_HOST / VALKEY_HOST to reach them
+# elsewhere, e.g. by container name from a dev container
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'ureport',
         'USER': 'ureport',
         'PASSWORD': 'nyaruka',
-        'HOST': 'localhost',
+        'HOST': os.environ.get('POSTGRES_HOST', 'localhost'),
         'PORT': '',
         'ATOMIC_REQUESTS': True,
         'OPTIONS': {
@@ -60,7 +64,7 @@ DATABASES = {
     }
 }
 
-VALKEY_HOST = "localhost"
+VALKEY_HOST = os.environ.get("VALKEY_HOST", "localhost")
 VALKEY_PORT = 6379
 VALKEY_DB = '1'
 

--- a/ureport/utils/tests.py
+++ b/ureport/utils/tests.py
@@ -51,8 +51,7 @@ class UtilsTest(UreportTest):
         self.poll = self.create_poll(self.org, "Poll 1", "uuid-1", self.education, self.admin)
 
     def clear_cache(self):
-        # hardcoded to localhost
-        r = valkey.StrictValkey(host="localhost", db=1)
+        r = valkey.StrictValkey(host=getattr(settings, "VALKEY_HOST", "localhost"), db=1)
         r.flushdb()
 
     def test_datetime_to_json_date(self):
@@ -546,7 +545,7 @@ class UtilsTest(UreportTest):
             CACHES={
                 "default": {
                     "BACKEND": "django_valkey.cache.ValkeyCache",
-                    "LOCATION": "redis://127.0.0.1:6379/1",
+                    "LOCATION": "redis://%s:6379/1" % getattr(settings, "VALKEY_HOST", "localhost"),
                 }
             }
         ):


### PR DESCRIPTION
`settings.py.postgres` (the settings CI and local development use) hardcoded `localhost` for postgres and valkey. It now reads `POSTGRES_HOST` / `VALKEY_HOST` from the environment, defaulting to `localhost`, so the same settings work when running inside a container (e.g. a dev container) where the services are reached by name.

Three tests also hardcoded `localhost` / `127.0.0.1` for valkey (`UtilsTest.clear_cache` and two `self.settings(CACHES=...)` overrides) and now use the configured host, so the suite runs anywhere the settings do. No behaviour change without the env vars set.