### PR TITLE
Prepare settings for running behind a load balancer

### DIFF
--- a/ureport/settings.py.prod
+++ b/ureport/settings.py.prod
@@ -34,7 +34,9 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 SECURE_BROWSER_XSS_FILTER = True
 SECURE_HSTS_PRELOAD = False
 SECURE_HSTS_SECONDS = 86400
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'HTTPS')
+# trust the proxy's scheme header; proxies and load balancers send the scheme in lowercase,
+# and Django compares the value exactly
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 SECURE_REDIRECT_EXEMPT =  []
 SECURE_SSL_HOST = None
 SECURE_SSL_REDIRECT = False
@@ -121,7 +123,9 @@ WHITENOISE_MAX_AGE = 3600
 
 LOGGING = {
     'version': 1,
-    'disable_existing_loggers': True,
+    # keep loggers that exist before Django configures logging — the WSGI server's own
+    # access and error loggers in particular — instead of silencing them
+    'disable_existing_loggers': False,
     'formatters': {
         'verbose': {
             'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s'
@@ -159,9 +163,6 @@ LOGGING = {
 # use our cache backend for sessions
 SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 SESSION_CACHE_ALIAS = "default"
-
-# trust connections that are coming in on this protocol
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'HTTPS')
 
 # compress arguments
 COMPRESS_CSS_HASHING_METHOD = 'content'

--- a/ureport/settings.py.staging
+++ b/ureport/settings.py.staging
@@ -35,7 +35,9 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 SECURE_BROWSER_XSS_FILTER = True
 SECURE_HSTS_PRELOAD =  False
 SECURE_HSTS_SECONDS = 86400
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'HTTPS')
+# trust the proxy's scheme header; proxies and load balancers send the scheme in lowercase,
+# and Django compares the value exactly
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 SECURE_REDIRECT_EXEMPT = []
 SECURE_SSL_HOST = None
 SECURE_SSL_REDIRECT = False
@@ -117,7 +119,9 @@ WHITENOISE_MAX_AGE = 3600
 
 LOGGING = {
     'version': 1,
-    'disable_existing_loggers': True,
+    # keep loggers that exist before Django configures logging — the WSGI server's own
+    # access and error loggers in particular — instead of silencing them
+    'disable_existing_loggers': False,
     'formatters': {
         'verbose': {
 
@@ -148,9 +152,6 @@ LOGGING = {
 # use our cache backend for sessions
 SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 SESSION_CACHE_ALIAS = "default"
-
-# trust connections that are coming in on this protocol
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'HTTPS')
 
 # compress arguments
 COMPRESS_CSS_HASHING_METHOD = 'content'

--- a/ureport/settings.py.staging
+++ b/ureport/settings.py.staging
@@ -16,7 +16,10 @@ SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]
 
 EMPTY_SUBDOMAIN_HOST = 'http://nigeria.ureport.staging.nyaruka.com'
 HOSTNAME = 'ureport.staging.nyaruka.com'
-ALLOWED_HOSTS = ['.nyaruka.com', '.ureport.in']
+# as prod: a load balancer's health checks arrive with the target's IP as the Host header,
+# and CommonMiddleware validates every request's host, so a domain allowlist here turns each
+# check into a 400. Host validation is the load balancer's job (it only forwards our domains).
+ALLOWED_HOSTS = ['*']
 
 SESSION_EXPIRE_AT_BROWSER_CLOSE = False
 SESSION_COOKIE_SECURE = True


### PR DESCRIPTION
Three settings changes needed once the app runs directly behind a load balancer rather than behind its own nginx:

- **Staging allows any host**, as prod already does. A load balancer's health checks arrive with the target's IP as the `Host` header, and `CommonMiddleware` validates every request's host, so the domain allowlist turned each check into a 400 and the target never went healthy. Host validation is the load balancer's job.
- **`SECURE_PROXY_SSL_HEADER` compares against lowercase `https`.** Proxies and load balancers send `X-Forwarded-Proto: https`, and Django compares the value exactly, so the literal `HTTPS` left `request.is_secure()` false behind them — failing CSRF origin checks on every POST (login included) and building absolute URLs as `http://`. An nginx config that sends the literal `HTTPS` needs to send `https` instead. The duplicate definition at the end of each settings file is dropped.
- **`disable_existing_loggers: False`** in the prod/staging `LOGGING`, so loggers that exist before Django configures logging — the WSGI server's own access and error loggers in particular — are no longer silenced (`gunicorn --access-logfile -` produced nothing before this).

Verified by loading both settings variants and checking the values, and that gunicorn's `access`/`error` loggers stay enabled after `dictConfig(LOGGING)`.